### PR TITLE
*: cleanup old references

### DIFF
--- a/dequeue/dequeue.go
+++ b/dequeue/dequeue.go
@@ -74,11 +74,11 @@ func New[T ingest.Identifiable](bucket, bucketFilesPrefix, bucketMetafilesPrefix
 
 		dequeuerErrorCounter: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "dequeuer_errors_total",
-			Help: "Number of errors that occured while syncing documents.",
+			Help: "Number of errors that occured while syncing items.",
 		}),
 		dequeuerAttemptCounter: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "dequeuer_attempts_total",
-			Help: "Number of document sync attempts.",
+			Help: "Number of item sync attempts.",
 		}),
 		webhookRequestsTotalCounter: promauto.With(r).NewCounterVec(
 			prometheus.CounterOpts{

--- a/queue/subscription.go
+++ b/queue/subscription.go
@@ -19,20 +19,20 @@ func newSubscription(sub *nats.Subscription, cv *prometheus.CounterVec) ingest.S
 	}
 }
 
-func (f *subscription) Close() error {
-	if f.sub == nil {
+func (s *subscription) Close() error {
+	if s.sub == nil {
 		return nil
 	}
-	return f.sub.Drain()
+	return s.sub.Drain()
 }
 
-func (f *subscription) Pop(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error) {
-	msgs, err := f.sub.Fetch(batch, opts...)
+func (s *subscription) Pop(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error) {
+	msgs, err := s.sub.Fetch(batch, opts...)
 	if err != nil {
-		f.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
+		s.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
 		return nil, err
 	}
-	f.queueInteractionsTotalCounter.WithLabelValues("pop", "success").Inc()
+	s.queueInteractionsTotalCounter.WithLabelValues("pop", "success").Inc()
 
 	return msgs, nil
 }


### PR DESCRIPTION
This commit does some cleanup to keep the ignest library generic and
abstrcted from a particular API.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
