### PR TITLE
ingest.go: add CleanUp method to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ type Client[T Identifiable] interface {
         // however in some cases it is possible to create
 	// the Object directly from the T.
 	Download(context.Context, T) (Object, error)
+	// CleanUp is called after an object is uploaded
+	// to object storage. In most cases, this will
+	// serve the purpose of removing the object from
+	// the source API so that it is no longer returned
+	// by the Nexter and as such is not resynchronized.
+	// This method must be idempotent and safe to call
+	// multiple times.
+	CleanUp(context.Context, T) error
 }
 
 // Identifiable must be implemented by the caller for their T.

--- a/dequeue/dequeue_test.go
+++ b/dequeue/dequeue_test.go
@@ -32,7 +32,7 @@ func TestDequeue(t *testing.T) {
 
 		sub.On("Close").Return(nil).Once()
 
-		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, logger, reg)
+		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -62,6 +62,7 @@ func TestDequeue(t *testing.T) {
 		sub.On("Close").Return(nil).Once()
 
 		c.On("Download", mock.Anything, mock.Anything).Return(obj, nil).Once()
+		c.On("CleanUp", mock.Anything, mock.Anything).Return(nil).Once()
 
 		obj.On("Len").Return(int64(64)).Once()
 		obj.On("MimeType").Return("plain/text").Once()
@@ -71,7 +72,7 @@ func TestDequeue(t *testing.T) {
 		mc.On("StatObject", mock.Anything, "bucket", "prefix/foo", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once().
 			On("StatObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
 
-		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, logger, reg)
+		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -105,7 +106,7 @@ func TestDequeue(t *testing.T) {
 
 		mc.On("StatObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything).Return(minio.ObjectInfo{}, nil).Once()
 
-		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, logger, reg)
+		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()

--- a/ingest.go
+++ b/ingest.go
@@ -65,6 +65,14 @@ type Client[T Identifiable] interface {
 	// however in some cases it is possible to create
 	// the Object directly from the T.
 	Download(context.Context, T) (Object, error)
+	// CleanUp is called after an object is uploaded
+	// to object storage. In most cases, this will
+	// serve the purpose of removing the object from
+	// the source API so that it is no longer returned
+	// by the Nexter and as such is not resynchronized.
+	// This method must be idempotent and safe to call
+	// multiple times.
+	CleanUp(context.Context, T) error
 }
 
 // Identifiable must be implemented by the caller for their T.

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -36,3 +36,16 @@ func (_m *Client[T]) Download(ctx context.Context, t T) (ingest.Object, error) {
 	}
 	return obj, err
 }
+
+// CleanUp is a mock function.
+func (_m *Client[T]) CleanUp(ctx context.Context, t T) error {
+	ret := _m.Called(ctx, t)
+
+	var err error
+	if rf, ok := ret.Get(0).(func(context.Context, T) error); ok {
+		err = rf(ctx, t)
+	} else {
+		err = ret.Error(0)
+	}
+	return err
+}


### PR DESCRIPTION
This commit adds a new `CleanUp` method to the `Client` to optionally
remove objects from the source API after they have been ingested. It
also adds a new argument to the dequeuer constructor to control the
optional clean up behavior.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
