### PR TITLE
Makefile: auto-generate README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ on:
 
 jobs:
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.0
+    - name: Docs
+      run: |
+        make README.md -B
+        git diff --exit-code
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,15 @@ PKG := github.com/connylabs/$(PROJECT)
 GO_FILES ?= $$(find . -name '*.go' -not -path './vendor/*')
 SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
+EMBEDMD_BINARY := $(shell pwd)/$(BIN_DIR)/embedmd
 GOLINT_BINARY := $(shell pwd)/$(BIN_DIR)/golint
 MOCKERY_BINARY := $(shell pwd)/$(BIN_DIR)/mockery
 
 $(BIN_DIR):
 	mkdir -p bin
+
+README.md: $(EMBEDMD_BINARY) ingest.go
+	$(EMBEDMD_BINARY) -w $@
 
 fmt:
 	@echo $(GO_PKGS)
@@ -83,3 +87,6 @@ $(GOLINT_BINARY): | $(BIN_DIR)
 
 $(MOCKERY_BINARY): | $(BIN_DIR)
 	go build -o $@ github.com/vektra/mockery/v2
+
+$(EMBEDMD_BINARY): | $(BIN_DIR)
+	go build -o $@ github.com/campoy/embedmd

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It can put either just an ID or the entire contents of the object into the queue
 
 For a new service you must implement the following `Nexter` interface:
 
+[embedmd]:# (ingest.go /\/\/ Nexter/ /}/)
 ```go
 // Nexter is able to list the elements available in the external API and returns them one by one.
 // A Nexter must be implemented for the specific service.
@@ -33,6 +34,7 @@ type Nexter[T any] interface {
 To use the Enqueuer create, a new one with `enqueue.New`.
 It implements the following interface:
 
+[embedmd]:# (ingest.go /\/\/ Enqueuer/ /}/)
 ```go
 // Enqueuer is able to enqueue elements into NATS.
 type Enqueuer interface {
@@ -47,6 +49,7 @@ The `Dequeuer` reads from the queue and uploads the object into object storage.
 You need implement the `Client` interface.
 **Note**: if the entire object is transported over the queue, then the `Download` operation can directly convert the given `T` into an object rather than download it from the API.
 
+[embedmd]:# (ingest.go /\/\/ Object / /}/)
 ```go
 // Object represents an object that can be uploaded into object storage.
 type Object interface {
@@ -56,18 +59,24 @@ type Object interface {
 	Len() int64
 	io.Reader
 }
+```
 
+[embedmd]:# (ingest.go /\/\/ Client/ /}/)
+```go
 // Client is able to create an Object from a T.
 // Client must be implemented by the caller.
 type Client[T Identifiable] interface {
 	// Download converts a T into an Object.
 	// In most cases it will use the ID of the T to
 	// download the object from an API,
-        // however in some cases it is possible to create
+	// however in some cases it is possible to create
 	// the Object directly from the T.
 	Download(context.Context, T) (Object, error)
 }
+```
 
+[embedmd]:# (ingest.go /\/\/ Identifiable/ /}/)
+```go
 // Identifiable must be implemented by the caller for their T.
 // The ID returned by ID() will be uses as a key  in object storage.
 type Identifiable interface {
@@ -79,6 +88,7 @@ type Identifiable interface {
 To use the Dequeuer, create a new one with `dequeuer.New`.
 It implements the following interface:
 
+[embedmd]:# (ingest.go /\/\/ Dequeuer/ /}/)
 ```go
 // Dequeuer is able to dequeue elements from the queue and upload objects to object storage.
 type Dequeuer interface {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/connylabs/ingest
 go 1.18
 
 require (
+	github.com/campoy/embedmd v1.0.0
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/go-kit/kit v0.12.0
+	github.com/go-kit/log v0.2.0
 	github.com/minio/minio-go/v7 v7.0.23
 	github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d
 	github.com/prometheus/client_golang v1.12.1
@@ -19,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
+github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tools.go
+++ b/tools.go
@@ -1,9 +1,10 @@
 //go:build tools
 // +build tools
 
-package main
+package ingest
 
 import (
+	_ "github.com/campoy/embedmd"
 	_ "github.com/vektra/mockery/v2"
 	_ "golang.org/x/lint/golint"
 )


### PR DESCRIPTION
Currently, maintaining the README is tedious because the developer must
copy interface definitions into Markdown. This commit simplifies the
workflow of making changes to the interfaces by allowing the README to
be automatically generated. It also adds a test to assert that the
documentation is up-to-date.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
