### PR TITLE
dequeue: always clean up

### DIFF
--- a/dequeue/dequeue_test.go
+++ b/dequeue/dequeue_test.go
@@ -104,6 +104,8 @@ func TestDequeue(t *testing.T) {
 		sub.On("Pop", 1, mock.Anything).Return([]*nats.Msg{}, nil)
 		sub.On("Close").Return(nil).Once()
 
+		c.On("CleanUp", mock.Anything, mock.Anything).Return(nil).Once()
+
 		mc.On("StatObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything).Return(minio.ObjectInfo{}, nil).Once()
 
 		d := New[*mocks.T]("bucket", "prefix", "meta", "", c, mc, q, "str", "con", "sub", 1, true, logger, reg)


### PR DESCRIPTION
Currently, the CleanUp method is only executed if an object was
_neither_ synced _nor_ marked. This is problematic, because it means
that objects that are already correctly stored will not be cleaned up,
even though they should not be re-processed. This commit fixes the logic
for the cleanup while also simplifying the function to make the logic
easier to follow, e.g. now, the code only ever has to call `mark` in one
place.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
