### PR TITLE
enhancement: actually lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PROJECT := ingest
 PKG := github.com/connylabs/$(PROJECT)
 
 GO_FILES ?= $$(find . -name '*.go' -not -path './vendor/*')
+GO_PKGS ?= $$(go list ./... | grep -v "$(PKG)/vendor")
 SRC := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 EMBEDMD_BINARY := $(shell pwd)/$(BIN_DIR)/embedmd

--- a/dequeue/dequeue_test.go
+++ b/dequeue/dequeue_test.go
@@ -50,7 +50,7 @@ func TestDequeue(t *testing.T) {
 		q := new(mocks.Queue)
 		mc := new(mocks.MinioClient)
 		sub := new(mocks.Subscription)
-		_t := &mocks.T{Id: "foo"}
+		_t := &mocks.T{MockID: "foo"}
 		data, _ := json.Marshal(_t)
 		msg := &nats.Msg{Data: data}
 		obj := new(mocks.Object)
@@ -93,7 +93,7 @@ func TestDequeue(t *testing.T) {
 		q := new(mocks.Queue)
 		mc := new(mocks.MinioClient)
 		sub := new(mocks.Subscription)
-		_t := &mocks.T{Id: "foo"}
+		_t := &mocks.T{MockID: "foo"}
 		data, _ := json.Marshal(_t)
 		msg := &nats.Msg{Data: data}
 		obj := new(mocks.Object)

--- a/enqueue/enqueue_test.go
+++ b/enqueue/enqueue_test.go
@@ -44,7 +44,7 @@ func TestEnqueue(t *testing.T) {
 		{
 			name: "one entry",
 			expect: func() (*mocks.Queue, *mocks.Nexter, *mocks.T) {
-				t := &mocks.T{Id: "foo"}
+				t := &mocks.T{MockID: "foo"}
 				data, _ := json.Marshal(t)
 				q := new(mocks.Queue)
 				q.On("Publish", "sub", data).Return(nil).Once()
@@ -58,9 +58,9 @@ func TestEnqueue(t *testing.T) {
 		{
 			name: "two entries",
 			expect: func() (*mocks.Queue, *mocks.Nexter, *mocks.T) {
-				t := &mocks.T{Id: "foo"}
+				t := &mocks.T{MockID: "foo"}
 				data, _ := json.Marshal(t)
-				t2 := &mocks.T{Id: "foo2"}
+				t2 := &mocks.T{MockID: "foo2"}
 				data2, _ := json.Marshal(t2)
 				q := new(mocks.Queue)
 				q.

--- a/mocks/Nexter.go
+++ b/mocks/Nexter.go
@@ -17,12 +17,12 @@ var (
 
 // T is a mock.
 type T struct {
-	Id string
+	MockID string
 }
 
-// ID returns the Id of T.
+// ID returns the ID of T.
 func (t *T) ID() string {
-	return t.Id
+	return t.MockID
 }
 
 // Nexter is a mock type for the Nexter type


### PR DESCRIPTION
Currently, no Go files are linted because there is no GO_PKGS variable
in Make. This commit adds this variable, triggering real linting, and
also renames a struct field about which golint was complaining.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
