### PR TITLE
cmd: don't wait interval before syncing

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,14 +28,16 @@ func NewEnqueuerRunner(ctx context.Context, e ingest.Enqueuer, interval time.Dur
 			return nil
 		}
 		for {
-			ticker := time.NewTicker(interval)
-			select {
-			case <-ticker.C:
+			{
 				ctx, cancel := context.WithTimeout(ctx, interval)
 				if err := e.Enqueue(ctx); err != nil {
 					level.Error(l).Log("msg", "failed to enqueue", "err", err.Error())
 				}
-				defer cancel()
+				cancel()
+			}
+			ticker := time.NewTicker(interval)
+			select {
+			case <-ticker.C:
 			case <-ctx.Done():
 				ticker.Stop()
 				return nil


### PR DESCRIPTION
This commit modifies the ingest library so that the enqueuer syncs
immediately and then waits, rather than waiting _interval_ before the
first sync.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
