### PR TITLE
storage: move stat to storage

### DIFF
--- a/mocks/storage.go
+++ b/mocks/storage.go
@@ -19,6 +19,26 @@ type Storage[T ingest.Identifiable] struct {
 	mock.Mock
 }
 
+// Stat is a mock function.
+func (_m *Storage[T]) Stat(ctx context.Context, element T) (*storage.ObjectInfo, error) {
+	ret := _m.Called(ctx, element)
+
+	var o *storage.ObjectInfo
+	if rf, ok := ret.Get(0).(func(context.Context, T) *storage.ObjectInfo); ok {
+		o = rf(ctx, element)
+	} else {
+		o = ret.Get(0).(*storage.ObjectInfo)
+	}
+
+	var err error
+	if rf, ok := ret.Get(1).(func(context.Context, T) error); ok {
+		err = rf(ctx, element)
+	} else {
+		err = ret.Error(1)
+	}
+	return o, err
+}
+
 // Store is a mock function.
 func (_m *Storage[T]) Store(ctx context.Context, element T, download func(context.Context, T) (ingest.Object, error)) (*url.URL, error) {
 	ret := _m.Called(ctx, element, download)

--- a/storage/s3/s3_test.go
+++ b/storage/s3/s3_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/connylabs/ingest/mocks"
 )
 
-func TestNew(t *testing.T) {
-	t.Run("one object", func(t *testing.T) {
+func TestStore(t *testing.T) {
+	t.Run("using meta objects", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		c := new(mocks.Client[*mocks.T])
 		mc := new(mocks.MinioClient)
@@ -28,8 +28,6 @@ func TestNew(t *testing.T) {
 
 		mc.On("PutObject", mock.Anything, "bucket", "prefix/foo", mock.Anything, int64(64), mock.Anything).Return(minio.UploadInfo{}, nil).Once().
 			On("PutObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything, int64(0), mock.Anything).Return(minio.UploadInfo{}, nil).Once()
-		mc.On("StatObject", mock.Anything, "bucket", "prefix/foo", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once().
-			On("StatObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
 
 		s := New[*mocks.T]("bucket", "prefix", "meta", mc, logger)
 
@@ -49,7 +47,69 @@ func TestNew(t *testing.T) {
 		obj.AssertExpectations(t)
 		c.AssertExpectations(t)
 	})
-	t.Run("object exists", func(t *testing.T) {
+	t.Run("not using meta objects", func(t *testing.T) {
+		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+		c := new(mocks.Client[*mocks.T])
+		mc := new(mocks.MinioClient)
+		_t := &mocks.T{MockID: "foo"}
+		obj := new(mocks.Object)
+
+		c.On("Download", mock.Anything, mock.Anything).Return(obj, nil).Once()
+
+		obj.On("Len").Return(int64(64)).Once()
+		obj.On("MimeType").Return("plain/text").Once()
+
+		mc.On("PutObject", mock.Anything, "bucket", "prefix/foo", mock.Anything, int64(64), mock.Anything).Return(minio.UploadInfo{}, nil).Once()
+
+		s := New[*mocks.T]("bucket", "prefix", "", mc, logger)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		u, err := s.Store(ctx, _t, c.Download)
+		if err != nil {
+			t.Error(err)
+		}
+
+		key := "s3://bucket/prefix/foo"
+		if u.String() != key {
+			t.Errorf("expected %q, got %q", key, u.String())
+		}
+
+		mc.AssertExpectations(t)
+		obj.AssertExpectations(t)
+		c.AssertExpectations(t)
+	})
+}
+
+func TestStat(t *testing.T) {
+	t.Run("no object, no meta object", func(t *testing.T) {
+		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+		c := new(mocks.Client[*mocks.T])
+		mc := new(mocks.MinioClient)
+		_t := &mocks.T{MockID: "foo"}
+		obj := new(mocks.Object)
+
+		mc.On("StatObject", mock.Anything, "bucket", "prefix/foo", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once().
+			On("StatObject", mock.Anything, "bucket", "meta/foo.done", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
+
+		s := New[*mocks.T]("bucket", "prefix", "meta", mc, logger)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		o, err := s.Stat(ctx, _t)
+		if !os.IsNotExist(err) {
+			t.Errorf("expected error to satisfy os.IsNotExist, got %v", err)
+		}
+
+		if o != nil {
+			t.Errorf("expected nil, got %v", o)
+		}
+
+		mc.AssertExpectations(t)
+		obj.AssertExpectations(t)
+		c.AssertExpectations(t)
+	})
+	t.Run("object, no meta object", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		c := new(mocks.Client[*mocks.T])
 		mc := new(mocks.MinioClient)
@@ -64,21 +124,21 @@ func TestNew(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
-		u, err := s.Store(ctx, _t, c.Download)
+		o, err := s.Stat(ctx, _t)
 		if err != nil {
 			t.Error(err)
 		}
 
 		key := "s3://bucket/prefix/foo"
-		if u.String() != key {
-			t.Errorf("expected %q, got %q", key, u.String())
+		if o.URI != key {
+			t.Errorf("expected %q, got %q", key, o.URI)
 		}
 
 		mc.AssertExpectations(t)
 		obj.AssertExpectations(t)
 		c.AssertExpectations(t)
 	})
-	t.Run("meta object exists", func(t *testing.T) {
+	t.Run("no object, meta object", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		c := new(mocks.Client[*mocks.T])
 		mc := new(mocks.MinioClient)
@@ -91,54 +151,21 @@ func TestNew(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
-		u, err := s.Store(ctx, _t, c.Download)
+		o, err := s.Stat(ctx, _t)
 		if err != nil {
 			t.Error(err)
 		}
 
 		key := "s3://bucket/prefix/foo"
-		if u.String() != key {
-			t.Errorf("expected %q, got %q", key, u.String())
+		if o.URI != key {
+			t.Errorf("expected %q, got %q", key, o.URI)
 		}
 
 		mc.AssertExpectations(t)
 		obj.AssertExpectations(t)
 		c.AssertExpectations(t)
 	})
-	t.Run("one object no done", func(t *testing.T) {
-		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
-		c := new(mocks.Client[*mocks.T])
-		mc := new(mocks.MinioClient)
-		_t := &mocks.T{MockID: "foo"}
-		obj := new(mocks.Object)
-
-		c.On("Download", mock.Anything, mock.Anything).Return(obj, nil).Once()
-
-		obj.On("Len").Return(int64(64)).Once()
-		obj.On("MimeType").Return("plain/text").Once()
-
-		mc.On("PutObject", mock.Anything, "bucket", "prefix/foo", mock.Anything, int64(64), mock.Anything).Return(minio.UploadInfo{}, nil).Once()
-		mc.On("StatObject", mock.Anything, "bucket", "prefix/foo", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
-
-		s := New[*mocks.T]("bucket", "prefix", "", mc, logger)
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-		defer cancel()
-		u, err := s.Store(ctx, _t, c.Download)
-		if err != nil {
-			t.Error(err)
-		}
-
-		key := "s3://bucket/prefix/foo"
-		if u.String() != key {
-			t.Errorf("expected %q, got %q", key, u.String())
-		}
-
-		mc.AssertExpectations(t)
-		obj.AssertExpectations(t)
-		c.AssertExpectations(t)
-	})
-	t.Run("one object no done", func(t *testing.T) {
+	t.Run("object exists", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		c := new(mocks.Client[*mocks.T])
 		mc := new(mocks.MinioClient)
@@ -151,14 +178,40 @@ func TestNew(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
-		u, err := s.Store(ctx, _t, c.Download)
+		o, err := s.Stat(ctx, _t)
 		if err != nil {
 			t.Error(err)
 		}
 
 		key := "s3://bucket/prefix/foo"
-		if u.String() != key {
-			t.Errorf("expected %q, got %q", key, u.String())
+		if o.URI != key {
+			t.Errorf("expected %q, got %q", key, o.URI)
+		}
+
+		mc.AssertExpectations(t)
+		obj.AssertExpectations(t)
+		c.AssertExpectations(t)
+	})
+	t.Run("no object", func(t *testing.T) {
+		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+		c := new(mocks.Client[*mocks.T])
+		mc := new(mocks.MinioClient)
+		_t := &mocks.T{MockID: "foo"}
+		obj := new(mocks.Object)
+
+		mc.On("StatObject", mock.Anything, "bucket", "prefix/foo", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
+
+		s := New[*mocks.T]("bucket", "prefix", "", mc, logger)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		o, err := s.Stat(ctx, _t)
+		if !os.IsNotExist(err) {
+			t.Errorf("expected error to satisfy os.IsNotExist, got %v", err)
+		}
+
+		if o != nil {
+			t.Errorf("expected nil, got %v", o)
 		}
 
 		mc.AssertExpectations(t)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,8 +7,17 @@ import (
 	"github.com/connylabs/ingest"
 )
 
+// ObjectInfo describes an object in storage.
+type ObjectInfo struct {
+	// URI is the location under which the object can be found.
+	URI string
+}
+
 // Storage must know how to store and stat objects.
 // it allows applications to plug different storage systems.
 type Storage[T ingest.Identifiable] interface {
+	// Stat can be used to find information about the object corresponding to the given element.
+	// If the object does not exist, then Stat returns an error satisfied by os.IsNotExist.
+	Stat(ctx context.Context, element T) (*ObjectInfo, error)
 	Store(ctx context.Context, element T, download func(context.Context, T) (ingest.Object, error)) (*url.URL, error)
 }


### PR DESCRIPTION
This commit adds a Stat method to the storage.Storage interface. This
allows the dequeuer to check if files need to be uploaded before doing
so. Currently the s3 storage performs this check internally, avoiding
extra uploads, however moving this to the dequeuer would allow all
storages to benefit from this functionality without needing to implement
the check themselves.

Unfortunately for the s3 storage, using done files complicates this
flow. There are two options:
1. Perform all of the stats again inside of the Store method to check
   what needs to be created. This means that in the worst case, a
   single upload can result in 4 stat calls, instead of the previous 2;
   or
2. Allow creating meta objects in the Stat method if the object exists
   but the meta object does not.

This commit takes the second approach, which simplifying the Store
method significantly, although it means that the Stat method has side
effects.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
