### PR TITLE
Webkook: stop calling Webkook with empty payload

### DIFF
--- a/dequeue/dequeue.go
+++ b/dequeue/dequeue.go
@@ -119,7 +119,7 @@ func (d *dequeuer[T]) Dequeue(ctx context.Context) error {
 			}
 		}
 
-		if d.webhookURL != "" {
+		if d.webhookURL != "" && len(uris) > 0 {
 			if err := d.callWebhook(ctx, uris); err != nil {
 				d.webhookRequestsTotalCounter.WithLabelValues("error").Inc()
 				level.Warn(d.l).Log("warn", "failed to call a webhook", "msg", err.Error())


### PR DESCRIPTION
This will put to many jobs into zieb work queue.
