### PR TITLE
storage: allow client to store in shared drives

### DIFF
--- a/storage/drive/drive.go
+++ b/storage/drive/drive.go
@@ -86,7 +86,7 @@ func (ds *driveStorage) Store(ctx context.Context, element ingest.Identifiable, 
 		return nil, fmt.Errorf("failed to download %s: %w", element.ID(), err)
 	}
 
-	f, err := ds.s.Files.Create(file).Media(object).Context(ctx).Do()
+	f, err := ds.s.Files.Create(file).Media(object).SupportsAllDrives(true).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, the Google Drive client is only configured to be able to
store objects in non-shared drives, even though it is configured to find
objects in shared drives. This commit aligns this behavior. Eventually
we may want to make this a configuration option for the storage that is
configurable though the destination yaml.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
