### PR TITLE
Don't Reuse Consumers

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -215,7 +215,7 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 				return fmt.Errorf("failed to connect to the queue: %v", err)
 			}
 			g.Add(
-				cmd.NewEnqueuerRunner(ctx, qc, *w.Interval, logger),
+				cmd.NewEnqueuerRunner(ctx, qc, time.Duration(*w.Interval), logger),
 				func(err error) {
 					// Do not cancel the enqueuer if other enqueuers exited cleanly.
 					// Instead, let the enqueuers finish.

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/connylabs/ingest/plugin"
 )
 
-var defaultInterval = 5 * time.Minute
+var defaultInterval = Duration(5 * time.Minute)
 
 // NewFromPath creates a new Config from the given file path.
 func NewFromPath(path string) (*Config, error) {
@@ -76,7 +76,7 @@ type Workflow struct {
 	Source       string
 	Destinations []string
 	CleanUp      bool
-	Interval     *time.Duration
+	Interval     *Duration
 	BatchSize    int
 	Webhook      string
 }

--- a/config/duration.go
+++ b/config/duration.go
@@ -11,12 +11,15 @@ import (
 // We need to make our own Duration type that implements UnmarshalJSON
 // to be able to unmarshal time.Duration.
 
+// Duration helps parse the durations in the configuration as time.Duration (see https://pkg.go.dev/time#ParseDuration).
 type Duration time.Duration
 
+// MarshalJSON overrides the the default marshal function.
 func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(d).String())
 }
 
+// UnmarshalJSON overrides the the default unmarshal function.
 func (d *Duration) UnmarshalJSON(b []byte) error {
 	var v interface{}
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/config/duration.go
+++ b/config/duration.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Thank you stackoverflow
+// https://stackoverflow.com/questions/48050945/how-to-unmarshal-json-into-durations
+// We need to make our own Duration type that implements UnmarshalJSON
+// to be able to unmarshal time.Duration.
+
+type Duration time.Duration
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		tmp, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(tmp)
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/enqueue/enqueue.go
+++ b/enqueue/enqueue.go
@@ -121,5 +121,6 @@ func (e *enqueuer) enqueue(ctx context.Context) error {
 		return err
 	}
 
+	level.Debug(e.l).Log("msg", "successfully enqueued items")
 	return nil
 }


### PR DESCRIPTION
cmd: create a consumer for each destination

Previsouly, ingest would reuse consumers for every destination, making
use of the multi-storage to store dequeued elements in multiple
destinations. This may make it harder to debug issues with storages and
cause unnecessary stats against successful storages. This PR changes the
logic so that every destination has its own consumer.

Note: the ingest stream _must_ use the interest retention policy to be
compatible with these consumers.

config: correctly unmarshal batch size

This commit modifies the type of the `batchSize` field of the
configuration so that `time.Duration`-style strings are correctly
unmarshaled into durations. Previously, only integers would be
unmarshaled into nanoseconds.
