### PR TITLE
dequeue/dequeue.go: improve logging

### DIFF
--- a/dequeue/dequeue.go
+++ b/dequeue/dequeue.go
@@ -79,9 +79,10 @@ func New(webhookURL string, c ingest.Client, s storage.Storage, q ingest.Queue, 
 }
 
 func (d *dequeuer) Dequeue(ctx context.Context) error {
+	level.Debug(d.l).Log("msg", "subscribing to stream", "consumer", d.consumerName, "stream", d.streamName)
 	sub, err := d.q.PullSubscribe(d.subjectName, d.consumerName, nats.BindStream(d.streamName))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to subscribe to stream: %w", err)
 	}
 
 	for {
@@ -102,8 +103,8 @@ func (d *dequeuer) Dequeue(ctx context.Context) error {
 
 		uris := make([]string, 0, d.batchSize)
 		for _, raw := range msgs {
-			//item, ok := any((*new(T))).(ingest.Codec)
-			//if !ok {
+			// item, ok := any((*new(T))).(ingest.Codec)
+			// if !ok {
 			item := new(ingest.SimpleCodec)
 			//}
 			if err := item.Unmarshal(raw.Data); err != nil {


### PR DESCRIPTION
Improve logging around subscribing to a stream. In case of a non existing
stream in NATS, the logged error would be "context canceled" which is
not very helpful.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
