### PR TITLE
cmd/ingest/main.go: add dry-run flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,17 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        push: false
+        tags: ghcr.io/connylabs/ingest:${{ steps.sha.outputs.sha }}
+
+  smoke test:
+    needs:
+    - container
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run smoke test
+      run: |
+        docker run --rm -v $(pwd)/test:/var/lib/config ghcr.io/connylabs/ingest:${{ steps.sha.outputs.sha }} --dry-run --config /var/lib/config/config.yaml
 
   push:
     if: github.event_name != 'pull_request'

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -149,6 +149,13 @@ func Main() error {
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
+	sources, destinations, err := c.ConfigurePlugins(ctx, *appFlags.pluginDirectory)
+	if err != nil {
+		return err
+	}
+	if *appFlags.dryRun {
+		return nil
+	}
 	q, err := queue.New(*appFlags.queueEndpoint, *appFlags.stream, []string{strings.Join([]string{*appFlags.subject, "*"}, ".")}, reg)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate queue: %w", err)
@@ -161,13 +168,6 @@ func Main() error {
 		}
 	}()
 	var g run.Group
-	sources, destinations, err := c.ConfigurePlugins(ctx, *appFlags.pluginDirectory)
-	if err != nil {
-		return err
-	}
-	if *appFlags.dryRun {
-		return nil
-	}
 	if err := runGroup(ctx, &g, q, appFlags, sources, destinations, c.Workflows, logger, reg); err != nil {
 		return err
 	}

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -253,6 +253,8 @@ workflows:
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	sources, destintations, err := c.ConfigurePlugins(ctx, fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH))
+
 	reg := prometheus.NewRegistry()
 
 	q, err := queue.New(natsEndpoint, stream, []string{fmt.Sprintf("%s.*", subject)}, reg)
@@ -276,12 +278,11 @@ workflows:
 	{
 		// enqueue
 		appFlags := &flags{
-			logLevel:        toPtr(logLevelAll),
-			mode:            toPtr(enqueueMode),
-			subject:         toPtr(subject),
-			pluginDirectory: toPtr(fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)),
+			logLevel: toPtr(logLevelAll),
+			mode:     toPtr(enqueueMode),
+			subject:  toPtr(subject),
 		}
-		require.Nil(t, runGroup(tctx, &g, q, appFlags, c, l, reg))
+		require.Nil(t, runGroup(tctx, &g, q, appFlags, sources, destintations, c.Workflows, l, reg))
 
 		wg.Add(1)
 		go func() {
@@ -298,7 +299,7 @@ workflows:
 			consumer:        toPtr(consumer),
 			pluginDirectory: toPtr(fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)),
 		}
-		require.Nil(t, runGroup(tctx, &g, q, appFlags, c, l, reg))
+		require.Nil(t, runGroup(tctx, &g, q, appFlags, sources, destintations, c.Workflows, l, reg))
 
 		wg.Add(1)
 		go func() {

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,0 +1,29 @@
+sources:
+- name: foo_1
+  type: s3
+  endpoint: localhost:9000
+  insecure: true
+  bucket: destination
+  prefix: prefix1/
+  metafilesPrefix: meta/
+  accessKeyID: AKIAIOSFODNN7EXAMPLE
+  secretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+destinations:
+- name: bar_1
+  type: s3
+  endpoint: localhost:9000
+  insecure: true
+  bucket: destination
+  prefix: prefix1/
+  metafilesPrefix: meta/
+  accessKeyID: AKIAIOSFODNN7EXAMPLE
+  secretAccessKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+  batchSize: 1
+  interval: 300s
+  cleanUp: true
+  webhook: http://localhost:8080


### PR DESCRIPTION
When this flag is set ingest will only load the configurations and
plugins and exit. This is helpful to make sure that all plugins can be
loaded and the configurations is valid.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
