### PR TITLE
dequeue: acknowledge messages that fail to process

### DIFF
--- a/dequeue/dequeue.go
+++ b/dequeue/dequeue.go
@@ -112,9 +112,9 @@ func (d *dequeuer) Dequeue(ctx context.Context) error {
 			u, err := d.process(ctx, item)
 			if err != nil {
 				level.Error(d.l).Log("msg", "failed to process message", "id", item.ID(), "name", item.Name(), "err", err.Error())
-				continue
+			} else {
+				level.Info(d.l).Log("msg", "successfully processed message", "id", item.ID(), "name", item.Name(), "data", string(raw.Data))
 			}
-			level.Info(d.l).Log("msg", "successfully processed message", "id", item.ID(), "name", item.Name(), "data", string(raw.Data))
 			if err := raw.AckSync(); err != nil {
 				level.Error(d.l).Log("msg", "failed to ack message", "id", item.ID(), "name", item.Name(), "err", err.Error())
 				continue


### PR DESCRIPTION
This commit refactors ingest so that we also ack messages that we cannot
process. This ensures that the messages that fail don't get stuck at the
top of the queue. Messages that fail are not cleaned up, so they _will_
get re-queued eventually. This helps un-block processing of messages.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
