### PR TITLE
config: explose storage plugin in metric label

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,7 +161,7 @@ func (c *Config) ConfigurePlugins(ctx context.Context, path string) (map[string]
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot instantiate source %q: %w", c.Sources[i].Name, err)
 		}
-		sources[c.Sources[i].Name] = s
+		sources[c.Sources[i].Name] = &SourceTyper{s, c.Sources[i].Type}
 	}
 	// Instantiate the destinations.
 	for i := range c.Destinations {
@@ -172,7 +172,7 @@ func (c *Config) ConfigurePlugins(ctx context.Context, path string) (map[string]
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot instantiate destination %q: %w", c.Destinations[i].Name, err)
 		}
-		destinations[c.Destinations[i].Name] = d
+		destinations[c.Destinations[i].Name] = &DestinationTyper{d, c.Destinations[i].Type}
 	}
 	return sources, destinations, nil
 }

--- a/config/plugin.go
+++ b/config/plugin.go
@@ -1,0 +1,27 @@
+package config
+
+import "github.com/connylabs/ingest/plugin"
+
+// SourceTyper implements the plugin.Source interface and exposes an additional method
+// to determine the kind of plugin that is wrapped.
+type SourceTyper struct {
+	plugin.Source
+	t string
+}
+
+// Type exposes the kind of plugin.
+func (st *SourceTyper) Type() string {
+	return st.t
+}
+
+// DestinationTyper implements the plugin.Typer interface and exposes an additional method
+// to determine the kind of plugin that is wrapped.
+type DestinationTyper struct {
+	plugin.Destination
+	t string
+}
+
+// Type exposes the kind of plugin.
+func (dt *DestinationTyper) Type() string {
+	return dt.t
+}


### PR DESCRIPTION
This commit enhances the metrics exposed by ingest so that storages will
have "plugin" label documenting what plugin they originated from. This
makes it nice to filter for storage errors by plugin kind.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
