### PR TITLE
cmd/ingest/main_test.go: allow multiple plugin paths

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -99,7 +99,7 @@ func Main() error {
 		logLevel:          flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels)),
 		mode:              flag.String("mode", "", fmt.Sprintf("Mode of the service. Possible values: %s", availableModes)),
 		help:              flag.Bool("h", false, "Show usage"),
-		pluginDirectories: flag.StringSlice("plugins", []string{filepath.Join(hd, ".config/ingest/plugins")}, "The directories in which to look for plugins. The plugin found first will take precedence"),
+		pluginDirectories: flag.StringSlice("plugins", []string{filepath.Join(hd, ".config/ingest/plugins")}, "The directories in which to look for plugins. Directories are searched in the order specified with the first match taking precedence"),
 		configPath:        flag.String("config", filepath.Join(hd, ".config/ingest/config"), "The path to the configuration file for ingest"),
 		dryRun:            flag.Bool("dry-run", false, "Only load the configuration and exit without performing any copy operations"),
 	}

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -253,7 +253,7 @@ workflows:
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sources, destintations, err := c.ConfigurePlugins(ctx, fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH))
+	sources, destintations, err := c.ConfigurePlugins(ctx, []string{fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)})
 	require.Nil(t, err)
 
 	reg := prometheus.NewRegistry()
@@ -294,11 +294,11 @@ workflows:
 	{
 		// dequeue
 		appFlags := &flags{
-			mode:            toPtr(dequeueMode),
-			subject:         toPtr(subject),
-			stream:          toPtr(stream),
-			consumer:        toPtr(consumer),
-			pluginDirectory: toPtr(fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)),
+			mode:              toPtr(dequeueMode),
+			subject:           toPtr(subject),
+			stream:            toPtr(stream),
+			consumer:          toPtr(consumer),
+			pluginDirectories: toPtr([]string{fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)}),
 		}
 		require.Nil(t, runGroup(tctx, &g, q, appFlags, sources, destintations, c.Workflows, l, reg))
 

--- a/config/config.go
+++ b/config/config.go
@@ -182,11 +182,12 @@ func (c *Config) ConfigurePlugins(ctx context.Context, paths []string) (map[stri
 }
 
 func firstPath(paths []string, filename string) (string, error) {
+	err := os.ErrNotExist
 	for _, p := range paths {
 		fpath := filepath.Join(p, filename)
-		if _, err := os.Stat(fpath); err == nil {
+		if _, err = os.Stat(fpath); err == nil {
 			return fpath, nil
 		}
 	}
-	return "", os.ErrNotExist
+	return "", err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -184,8 +184,7 @@ func (c *Config) ConfigurePlugins(ctx context.Context, paths []string) (map[stri
 func firstPath(paths []string, filename string) (string, error) {
 	for _, p := range paths {
 		fpath := filepath.Join(p, filename)
-		_, err := os.Stat(fpath)
-		if err == nil {
+		if _, err := os.Stat(fpath); err == nil {
 			return fpath, nil
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	stdplugin "plugin"
+	"syscall"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -182,12 +183,14 @@ func (c *Config) ConfigurePlugins(ctx context.Context, paths []string) (map[stri
 }
 
 func firstPath(paths []string, filename string) (string, error) {
-	err := os.ErrNotExist
 	for _, p := range paths {
 		fpath := filepath.Join(p, filename)
-		if _, err = os.Stat(fpath); err == nil {
-			return fpath, nil
+		if _, err := os.Stat(fpath); errors.Is(err, syscall.ENOENT) {
+			continue
+		} else if err != nil {
+			return "", err
 		}
+		return fpath, nil
 	}
-	return "", err
+	return "", os.ErrNotExist
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name   string
+		paths  []string
+		config []byte
+		err    error
+	}{
+		{
+			name:  "one path",
+			paths: []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:  "two path",
+			paths: []string{"../bin/plugin/to/nowhere", fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := New(tc.config)
+			require.Nil(t, err)
+
+			_, _, err = c.ConfigurePlugins(ctx, tc.paths)
+			assert.ErrorIs(t, err, tc.err, errors.Unwrap(err))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/nats-io/natscli v0.0.33
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.12.2
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/vektra/mockery/v2 v2.10.2
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
@@ -130,7 +131,6 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.10.1 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect


### PR DESCRIPTION
This PR makes it possible to specify multiple plugin paths. The first
plugin found will take precedence over plugins specified later.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
