### PR TITLE
Work on batch concurrently

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -245,6 +245,7 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 					strings.Join([]string{*appFlags.consumer, w.Name, d}, "__"),
 					strings.Join([]string{*appFlags.subject, w.Name}, "."),
 					w.BatchSize,
+					w.Concurrency,
 					w.CleanUp,
 					logger,
 					reg,

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ type Workflow struct {
 	Destinations []string
 	CleanUp      bool
 	Interval     *Duration
+	Concurrency  int
 	BatchSize    int
 	Webhook      string
 }
@@ -135,6 +136,9 @@ func (c *Config) ConfigurePlugins(ctx context.Context, paths []string) (map[stri
 		}
 		if w.BatchSize == 0 {
 			c.Workflows[i].BatchSize = ingest.DefaultBatchSize
+		}
+		if w.Concurrency == 0 {
+			c.Workflows[i].Concurrency = c.Workflows[i].BatchSize
 		}
 	}
 	// Instantiate the plugins.

--- a/dequeue/dequeue_test.go
+++ b/dequeue/dequeue_test.go
@@ -37,7 +37,7 @@ func TestDequeue(t *testing.T) {
 
 		sub.On("Close").Return(nil).Once()
 
-		d := New("", c, s, q, "str", "con", "sub", 1, true, logger, reg)
+		d := New("", c, s, q, "str", "con", "sub", 1, 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -72,7 +72,7 @@ func TestDequeue(t *testing.T) {
 		s.On("Stat", mock.Anything, ingest.NewCodec(_t)).Return((*storage.ObjectInfo)(nil), fs.ErrNotExist).Once()
 		s.On("Store", mock.Anything, ingest.NewCodec(_t), mock.Anything).Return(&url.URL{Scheme: "s3", Host: "bucket", Path: "prefix/foo"}, nil).Once()
 
-		d := New("", c, s, q, "str", "con", "sub", 1, true, logger, reg)
+		d := New("", c, s, q, "str", "con", "sub", 1, 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()
@@ -134,7 +134,7 @@ func TestDequeue(t *testing.T) {
 
 		s.On("Stat", mock.Anything, ingest.NewCodec(_t)).Return((*storage.ObjectInfo)(nil), nil).Once()
 
-		d := New("", c, s, q, "str", "con", "sub", 1, true, logger, reg)
+		d := New("", c, s, q, "str", "con", "sub", 1, 1, true, logger, reg)
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 		defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/vektra/mockery/v2 v2.10.2
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	google.golang.org/api v0.63.0
 )
 
@@ -154,7 +155,6 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
Add a Concurrency option to every workflow with default to BatchSize.
Each batch will be worked on by max <Concurrency> go routines.
