### PR TITLE
*: cleanup exported identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Ingest is a pluggable tool that makes it easy to orchestrate the synchronization
 ## Concept
 
 Ingest includes a main binary and some plugins for some common storage systems, like S3.
-Each plugin can implement a data source, a target or both.
-The S3 plugin implements both the source and target interface, but some plugins may only be able to act as either of them.
+Each plugin can implement a data source, a destination, or both.
+The S3 plugin implements both the source and destination interface, but some plugins may only be able to act as either of them.
 The plugins are loaded at runtime and enable users to implement their own custom plugins.
 
 ### Workflows
 
-A workflow specifies a data source and one or more targets.
-When configured, objects from the source will be copied to all targets.
+A workflow specifies a data source and one or more destinations.
+When configured, objects from the source will be copied to all destinations.
 
 ## Configuration
 
@@ -62,7 +62,7 @@ It will scan the configured sources and push a message for each item in the sour
 
 The other part is the dequeuer.
 It is started with the flag `--mode=dequeue`.
-It will pop messages from the NATS stream and copy each object identified by the [NATS](https://nats.io/) message to the configured targets.
+It will pop messages from the NATS stream and copy each object identified by the [NATS](https://nats.io/) message to the configured destinations.
 
 
 

--- a/plugin/cmd.go
+++ b/plugin/cmd.go
@@ -34,13 +34,13 @@ func RunPluginServer(s Source, d Destination) {
 	})
 
 	pluginMap := map[string]hplugin.Plugin{
-		"source": &PluginSource{
-			Impl: s,
+		"source": &pluginSource{
+			impl: s,
 			ctx:  ctx,
 			l:    logger.With("component", "source"),
 		},
-		"destination": &PluginDestination{
-			Impl: d,
+		"destination": &pluginDestination{
+			impl: d,
 			ctx:  ctx,
 			l:    logger.With("component", "destination"),
 		},

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -33,34 +33,32 @@ type Destination interface {
 	Configure(map[string]any) error
 }
 
-type PluginSource struct {
-	Impl Source
-
-	l   hclog.Logger
-	ctx context.Context
+type pluginSource struct {
+	impl Source
+	l    hclog.Logger
+	ctx  context.Context
 }
 
-func (p *PluginSource) Server(mb *hplugin.MuxBroker) (interface{}, error) {
-	return &pluginSourceRPCServer{Impl: p.Impl, mb: mb, l: p.l, ctx: p.ctx}, nil
+func (p *pluginSource) Server(mb *hplugin.MuxBroker) (interface{}, error) {
+	return &pluginSourceRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx}, nil
 }
 
-func (p *PluginSource) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p *pluginSource) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return &pluginSourceRPC{client: c, mb: mb}, nil
 }
 
-type PluginDestination struct {
-	Impl Destination
-
-	l   hclog.Logger
-	ctx context.Context
+type pluginDestination struct {
+	impl Destination
+	l    hclog.Logger
+	ctx  context.Context
 }
 
-func (p *PluginDestination) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p *pluginDestination) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return &pluginDestinationRPC{client: c, mb: mb}, nil
 }
 
-func (p *PluginDestination) Server(mb *hplugin.MuxBroker) (interface{}, error) {
-	return &pluginDestinationRPCServer{Impl: p.Impl, mb: mb, l: p.l, ctx: p.ctx}, nil
+func (p *pluginDestination) Server(mb *hplugin.MuxBroker) (interface{}, error) {
+	return &pluginDestinationRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx}, nil
 }
 
 func NewPlugin(ctx context.Context, path string) (Destination, Source, error) {
@@ -72,8 +70,8 @@ func NewPlugin(ctx context.Context, path string) (Destination, Source, error) {
 
 	// pluginMap is the map of plugins we can dispense.
 	pluginMap := map[string]hplugin.Plugin{
-		"destination": &PluginDestination{},
-		"source":      &PluginSource{},
+		"destination": &pluginDestination{},
+		"source":      &pluginSource{},
 	}
 
 	logger := hclog.New(&hclog.LoggerOptions{

--- a/plugins/noop/main.go
+++ b/plugins/noop/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	iplugin.RunPluginServer(iplugin.NewNoopSource(iplugin.DefaultLogger), iplugin.NewNoopStore(iplugin.DefaultLogger))
+	iplugin.RunPluginServer(iplugin.NewNoopSource(iplugin.DefaultLogger), iplugin.NewNoopDestination(iplugin.DefaultLogger))
 }

--- a/plugins/s3/main.go
+++ b/plugins/s3/main.go
@@ -66,7 +66,7 @@ func (d *destination) Configure(config map[string]interface{}) error {
 }
 
 // Configure will configure the source with the values given by config.
-func (p *source) Configure(config map[string]interface{}) error {
+func (s *source) Configure(config map[string]interface{}) error {
 	sc := new(sourceConfig)
 	err := mapstructure.Decode(config, sc)
 	if err != nil {
@@ -82,10 +82,10 @@ func (p *source) Configure(config map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	p.bucket = sc.Bucket
-	p.mc = mc
-	p.prefix = sc.Prefix
-	p.recursive = sc.Recursive
+	s.bucket = sc.Bucket
+	s.mc = mc
+	s.prefix = sc.Prefix
+	s.recursive = sc.Recursive
 
 	return nil
 }


### PR DESCRIPTION
This commit cleans up some of the identifiers that do not need to be
exported, standardizes the receiver names in methods, and cleans up the
README.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
