### PR TITLE
jet stream maximum messages

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -74,6 +74,7 @@ type flags struct {
 	stream            *string
 	subject           *string
 	consumer          *string
+	maxMsgs           *int64
 	printVersion      *bool
 	logLevel          *string
 	mode              *string
@@ -96,7 +97,8 @@ func Main() error {
 		replicas:          flag.Int("stream-replicas", 1, "The replicas of the NATS stream"),
 		stream:            flag.String("stream", "ingest", "The stream name to which to connect"),
 		subject:           flag.String("subject", "ingest", "The subject name to which to connect"),
-		consumer:          flag.String("consumer", "ingest", "The prefix to use for dymanically created consumer names"),
+		consumer:          flag.String("consumer", "ingest", "The prefix to use for dynamically created consumer names"),
+		maxMsgs:           flag.Int64("max-msgs", 1000000, "The maximum amount of messages in the jet stream"),
 		printVersion:      flag.Bool("version", false, "Show version"),
 		logLevel:          flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels)),
 		mode:              flag.String("mode", "", fmt.Sprintf("Mode of the service. Possible values: %s", availableModes)),
@@ -158,7 +160,7 @@ func Main() error {
 	if *appFlags.dryRun {
 		return nil
 	}
-	q, err := queue.New(*appFlags.queueEndpoint, *appFlags.stream, *appFlags.replicas, []string{strings.Join([]string{*appFlags.subject, "*"}, ".")}, reg)
+	q, err := queue.New(*appFlags.queueEndpoint, *appFlags.stream, *appFlags.replicas, []string{strings.Join([]string{*appFlags.subject, "*"}, ".")}, *appFlags.maxMsgs, reg)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate queue: %w", err)
 	}

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -98,7 +98,7 @@ func Main() error {
 		stream:            flag.String("stream", "ingest", "The stream name to which to connect"),
 		subject:           flag.String("subject", "ingest", "The subject name to which to connect"),
 		consumer:          flag.String("consumer", "ingest", "The prefix to use for dynamically created consumer names"),
-		maxMsgs:           flag.Int64("max-msgs", 1000000, "The maximum amount of messages in the jet stream"),
+		maxMsgs:           flag.Int64("max-msgs", 0, "The maximum amount of messages in the jet stream. Set to 0 to remove limit"),
 		printVersion:      flag.Bool("version", false, "Show version"),
 		logLevel:          flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels)),
 		mode:              flag.String("mode", "", fmt.Sprintf("Mode of the service. Possible values: %s", availableModes)),

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -263,7 +263,7 @@ workflows:
 
 	reg := prometheus.NewRegistry()
 
-	q, err := queue.New(natsEndpoint, stream, 1, []string{fmt.Sprintf("%s.*", subject)}, reg)
+	q, err := queue.New(natsEndpoint, stream, 1, []string{fmt.Sprintf("%s.*", subject)}, 1000, reg)
 	require.Nil(t, err)
 
 	l := log.NewJSONLogger(os.Stdout)

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -20,7 +20,7 @@ type queue struct {
 }
 
 // New is able to connect to the queue
-func New(url string, stream string, replicas int, subjects []string, reg prometheus.Registerer) (ingest.Queue, error) {
+func New(url string, stream string, replicas int, subjects []string, maxMsgs int64, reg prometheus.Registerer) (ingest.Queue, error) {
 	conn, err := nats.Connect(url)
 	if err != nil {
 		return &queue{conn: nil}, err
@@ -35,6 +35,7 @@ func New(url string, stream string, replicas int, subjects []string, reg prometh
 		Subjects:  subjects,
 		Retention: nats.InterestPolicy,
 		Replicas:  replicas,
+		MaxMsgs:   maxMsgs,
 	})
 	if errors.Is(err, nats.ErrStreamNameAlreadyInUse) {
 		si, err := js.StreamInfo(stream)


### PR DESCRIPTION
Allow to configure the ingest jet stream with a maximum amount of
allowed messages flag.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
