### PR TITLE
NATS stream replicas

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -70,6 +70,7 @@ func main() {
 type flags struct {
 	listenInternal    *string
 	queueEndpoint     *string
+	replicas          *int
 	stream            *string
 	subject           *string
 	consumer          *string
@@ -92,6 +93,7 @@ func Main() error {
 	appFlags := &flags{
 		listenInternal:    flag.String("listen", ":9090", "The address at which to listen for health and metrics"),
 		queueEndpoint:     flag.String("queue-endpoint", "nats://localhost:4222", "The queue endpoint to which to connect"),
+		replicas:          flag.Int("stream-replicas", 1, "The replicas of the NATS stream"),
 		stream:            flag.String("stream", "ingest", "The stream name to which to connect"),
 		subject:           flag.String("subject", "ingest", "The subject name to which to connect"),
 		consumer:          flag.String("consumer", "ingest", "The prefix to use for dymanically created consumer names"),
@@ -156,7 +158,7 @@ func Main() error {
 	if *appFlags.dryRun {
 		return nil
 	}
-	q, err := queue.New(*appFlags.queueEndpoint, *appFlags.stream, []string{strings.Join([]string{*appFlags.subject, "*"}, ".")}, reg)
+	q, err := queue.New(*appFlags.queueEndpoint, *appFlags.stream, *appFlags.replicas, []string{strings.Join([]string{*appFlags.subject, "*"}, ".")}, reg)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate queue: %w", err)
 	}

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -263,7 +263,7 @@ workflows:
 
 	reg := prometheus.NewRegistry()
 
-	q, err := queue.New(natsEndpoint, stream, []string{fmt.Sprintf("%s.*", subject)}, reg)
+	q, err := queue.New(natsEndpoint, stream, 1, []string{fmt.Sprintf("%s.*", subject)}, reg)
 	require.Nil(t, err)
 
 	l := log.NewJSONLogger(os.Stdout)

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -20,7 +20,7 @@ type queue struct {
 }
 
 // New is able to connect to the queue
-func New(url string, stream string, subjects []string, reg prometheus.Registerer) (ingest.Queue, error) {
+func New(url string, stream string, replicas int, subjects []string, reg prometheus.Registerer) (ingest.Queue, error) {
 	conn, err := nats.Connect(url)
 	if err != nil {
 		return &queue{conn: nil}, err
@@ -34,6 +34,7 @@ func New(url string, stream string, subjects []string, reg prometheus.Registerer
 		Name:      stream,
 		Subjects:  subjects,
 		Retention: nats.InterestPolicy,
+		Replicas:  replicas,
 	})
 	if errors.Is(err, nats.ErrStreamNameAlreadyInUse) {
 		si, err := js.StreamInfo(stream)


### PR DESCRIPTION
Allow configuring the replica count of the ingest stream.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
