### PR TITLE
Logging and Metrics

### DIFF
--- a/dequeue/dequeue.go
+++ b/dequeue/dequeue.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -97,8 +98,11 @@ func (d *dequeuer) Dequeue(ctx context.Context) error {
 		msgs, err := sub.Pop(d.batchSize, nats.Context(tctx))
 		cancel()
 		if err != nil {
-			level.Error(d.l).Log("msg", "failed to dequeue messages from queue", "err", err.Error())
+			if !errors.Is(err, context.Canceled) {
+				level.Error(d.l).Log("msg", "failed to dequeue messages from queue", "err", err.Error())
+			}
 			continue
+
 		}
 		level.Info(d.l).Log("msg", fmt.Sprintf("dequeued %d messages from queue", len(msgs)))
 

--- a/enqueue/enqueue.go
+++ b/enqueue/enqueue.go
@@ -71,7 +71,7 @@ func (e *enqueuer) enqueue(ctx context.Context) error {
 
 	codec, err := e.n.Next(ctx)
 	count := 0
-	for ; err != nil; codec, err = e.n.Next(ctx) {
+	for ; err == nil; codec, err = e.n.Next(ctx) {
 		data, err := codec.Marshal()
 		if err != nil {
 			return fmt.Errorf("failed to marshal retrieved item: %w", err)

--- a/queue/subscription.go
+++ b/queue/subscription.go
@@ -1,9 +1,6 @@
 package queue
 
 import (
-	"context"
-	"errors"
-
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -32,9 +29,7 @@ func (s *subscription) Close() error {
 func (s *subscription) Pop(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error) {
 	msgs, err := s.sub.Fetch(batch, opts...)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			s.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
-		}
+		s.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
 		return nil, err
 	}
 	s.queueInteractionsTotalCounter.WithLabelValues("pop", "success").Inc()

--- a/queue/subscription.go
+++ b/queue/subscription.go
@@ -1,6 +1,9 @@
 package queue
 
 import (
+	"context"
+	"errors"
+
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -29,7 +32,9 @@ func (s *subscription) Close() error {
 func (s *subscription) Pop(batch int, opts ...nats.PullOpt) ([]*nats.Msg, error) {
 	msgs, err := s.sub.Fetch(batch, opts...)
 	if err != nil {
-		s.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
+		if !errors.Is(err, context.Canceled) {
+			s.queueInteractionsTotalCounter.WithLabelValues("pop", "error").Inc()
+		}
 		return nil, err
 	}
 	s.queueInteractionsTotalCounter.WithLabelValues("pop", "success").Inc()


### PR DESCRIPTION
 - stop increasing the queue errors counter if the context deadline
   exceeded. This just means that no new items were in the queue. No
   error (tbd)
 - stop logging "attempting to get next item from nexter, but log how
   many items were fetched from the nexter
