### PR TITLE
storage: use multi-storage

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -268,7 +268,7 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 			}
 			s := storage.NewMultiStorage(ss...)
 			if len(ss) > 1 {
-				s = storage.NewInstrumentedStorage(s, prometheus.WrapRegistererWith(prometheus.Labels{"destination": "multi"}, reg))
+				s = storage.NewInstrumentedStorage(s, prometheus.WrapRegistererWith(prometheus.Labels{"destination": "multi", "plugin": "multi"}, reg))
 			}
 			d := dequeue.New(
 				w.Webhook, sources[w.Source],

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -254,34 +254,43 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 			)
 		case dequeueMode:
 			logger := log.With(logger, "mode", dequeueMode)
+			var ss []storage.Storage
 			for _, d := range w.Destinations {
-				reg := prometheus.WrapRegistererWith(prometheus.Labels{"destination": d}, reg)
 				t := "unknown"
 				if dt, ok := destinations[d].(config.DestinationTyper); ok {
 					t = dt.Type()
 				}
-				d := dequeue.New(
-					w.Webhook, sources[w.Source],
-					storage.NewInstrumentedStorage(destinations[d], prometheus.WrapRegistererWith(prometheus.Labels{"plugin": t}, reg)),
-					q,
-					*appFlags.stream,
-					strings.Join([]string{*appFlags.consumer, w.Name, d}, "__"),
-					strings.Join([]string{*appFlags.subject, w.Name}, "."),
-					w.BatchSize,
-					w.Concurrency,
-					w.CleanUp,
-					logger,
-					reg,
-				)
-				ctx, cancel := context.WithCancel(ctx)
-				g.Add(
-					cmd.NewDequeuerRunner(ctx, d, logger),
-					func(error) {
-						cancel()
-					},
-				)
-
+				reg := prometheus.WrapRegistererWith(prometheus.Labels{
+					"destination": d,
+					"plugin":      t,
+				}, reg)
+				ss = append(ss, storage.NewInstrumentedStorage(destinations[d], reg))
 			}
+			s := storage.NewMultiStorage(ss...)
+			if len(ss) > 1 {
+				s = storage.NewInstrumentedStorage(s, prometheus.WrapRegistererWith(prometheus.Labels{"destination": "multi"}, reg))
+			}
+			d := dequeue.New(
+				w.Webhook, sources[w.Source],
+				s,
+				q,
+				*appFlags.stream,
+				strings.Join([]string{*appFlags.consumer, w.Name}, "__"),
+				strings.Join([]string{*appFlags.subject, w.Name}, "."),
+				w.BatchSize,
+				w.Concurrency,
+				w.CleanUp,
+				logger,
+				reg,
+			)
+			ctx, cancel := context.WithCancel(ctx)
+			g.Add(
+				cmd.NewDequeuerRunner(ctx, d, logger),
+				func(error) {
+					cancel()
+				},
+			)
+
 		default:
 			flag.Usage()
 			return fmt.Errorf("unsupported mode %q", *appFlags.mode)

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -254,7 +254,7 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 			)
 		case dequeueMode:
 			logger := log.With(logger, "mode", dequeueMode)
-			var ss []storage.Storage
+			ss := make([]storage.Storage, 0, len(w.Destinations))
 			for _, d := range w.Destinations {
 				t := "unknown"
 				if dt, ok := destinations[d].(config.DestinationTyper); ok {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -148,5 +148,8 @@ func (m multiStorage) Store(ctx context.Context, element ingest.Codec, obj inges
 // Elements are stored across all storages.
 // Whenever multiple values are expected, the first storage's result is always given.
 func NewMultiStorage(s ...Storage) Storage {
+	if len(s) == 1 {
+		return s[0]
+	}
 	return multiStorage(s)
 }


### PR DESCRIPTION
Currently, the multi-storage implementation is unused, which means that
workflows with multiple destinations _cannot_ enable cleanup or else
files may be deleted in the source before every storage has had a chance
to upload it.

To work around this limitation, let's re-enable the use of
storage.MultiStorage. Note: although the consumer the name and number of
consumers has changed, elements do not need to be re-queued. This
convenience is enabled by the fact that each consumer has its own view
of the stream for the workflow. Old consumers suffixed with
`__<destination>` will need to be manually deleted from NATS.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
