### PR TITLE
metrics: fix plugin label

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -258,7 +258,7 @@ func runGroup(ctx context.Context, g *run.Group, q ingest.Queue, appFlags *flags
 			ss := make([]storage.Storage, 0, len(w.Destinations))
 			for _, d := range w.Destinations {
 				t := "unknown"
-				if dt, ok := destinations[d].(config.DestinationTyper); ok {
+				if dt, ok := destinations[d].(*config.DestinationTyper); ok {
 					t = dt.Type()
 				}
 				reg := prometheus.WrapRegistererWith(prometheus.Labels{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,7 +77,15 @@ workflows:
 
 			pm := &plugin.PluginManager{}
 			t.Cleanup(pm.Stop)
-			_, _, err = c.ConfigurePlugins(pm, tc.paths)
+			ss, ds, err := c.ConfigurePlugins(pm, tc.paths)
+			for _, s := range ss {
+				_, ok := s.(*SourceTyper)
+				assert.True(t, ok)
+			}
+			for _, d := range ds {
+				_, ok := d.(*DestinationTyper)
+				assert.True(t, ok)
+			}
 			assert.ErrorIs(t, err, tc.err, errors.Unwrap(err))
 		})
 	}


### PR DESCRIPTION
Currently, metrics are labeled with `plugin="unknown"` because we are
failing a type assertion, which makes it hard to debug which plugin is
causing errors. This commit fixes the assertion and adds a test. We
should consider using a `SourceTyper` and `DestinationTyper` interface
rather than structs/structpointers.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
