### PR TITLE
config: allow skipping failed workflows

### DIFF
--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -253,7 +253,9 @@ workflows:
 	rawConfig, err := io.ReadAll(b)
 	require.NoError(t, err)
 
-	c, err := config.New(rawConfig)
+	reg := prometheus.NewRegistry()
+
+	c, err := config.New(rawConfig, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -261,10 +263,8 @@ workflows:
 
 	pm := &plugin.PluginManager{}
 	t.Cleanup(pm.Stop)
-	sources, destintations, err := c.ConfigurePlugins(pm, []string{fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)})
+	sources, destintations, err := c.ConfigurePlugins(pm, []string{fmt.Sprintf("../../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)}, true)
 	require.NoError(t, err)
-
-	reg := prometheus.NewRegistry()
 
 	q, err := queue.New(natsEndpoint, stream, 1, []string{fmt.Sprintf("%s.*", subject)}, 1000, reg)
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,26 +1,31 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 	"testing"
 
 	"github.com/connylabs/ingest/plugin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		paths  []string
-		config []byte
-		err    error
+		name          string
+		paths         []string
+		config        []byte
+		err           error
+		strict        bool
+		nSources      int
+		nDestinations int
 	}{
 		{
-			name:  "one path",
-			paths: []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			name:          "one path",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      2,
+			nDestinations: 2,
 			config: []byte(`
 sources:
 - name: foo_1
@@ -45,8 +50,10 @@ workflows:
 `),
 		},
 		{
-			name:  "two path",
-			paths: []string{"../bin/plugin/to/nowhere", fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			name:          "two path",
+			paths:         []string{"../bin/plugin/to/nowhere", fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      2,
+			nDestinations: 2,
 			config: []byte(`
 sources:
 - name: foo_1
@@ -58,6 +65,262 @@ destinations:
   type: s3
 - name: bar_2
   type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:          "unused sources and destinations",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      2,
+			nDestinations: 2,
+			config: []byte(`
+sources:
+- name: unused_1
+  type: s3
+- name: unused_2
+  type: s3
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: unused_1
+  type: s3
+- name: unused_2
+  type: s3
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:   "strict workflow referencing non-existant source",
+			paths:  []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			err:    fmt.Errorf("workflow %q references non-existent source %q", "foo_2-bar_1-bar_2", "foo_2"),
+			strict: true,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:   "strict workflow referencing invalid source",
+			paths:  []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			err:    fmt.Errorf("cannot instantiate source %q", "foo_2"),
+			strict: true,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+  bucket: 0
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:          "workflow referencing non-existant source",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      1,
+			nDestinations: 1,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:          "workflow referencing invalid source",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      1,
+			nDestinations: 1,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+  bucket: 0
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:   "strict workflow referencing non-existant destination",
+			paths:  []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			err:    fmt.Errorf("workflow %q references non-existent destination %q", "foo_2-bar_1-bar_2", "bar_2"),
+			strict: true,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:   "strict workflow referencing invalid destination",
+			paths:  []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			err:    fmt.Errorf("cannot instantiate destination %q", "bar_2"),
+			strict: true,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+  bucket: 0
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:          "workflow referencing non-existant destination",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      2,
+			nDestinations: 1,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+workflows:
+- name: foo_1-bar_1
+  source: foo_1
+  destinations:
+  - bar_1
+- name: foo_2-bar_1-bar_2
+  source: foo_2
+  destinations:
+  - bar_1
+  - bar_2
+`),
+		},
+		{
+			name:          "workflow referencing invalid destination",
+			paths:         []string{fmt.Sprintf("../bin/plugin/%s/%s", runtime.GOOS, runtime.GOARCH)},
+			nSources:      2,
+			nDestinations: 1,
+			config: []byte(`
+sources:
+- name: foo_1
+  type: s3
+- name: foo_2
+  type: s3
+destinations:
+- name: bar_1
+  type: s3
+- name: bar_2
+  type: s3
+  bucket: 0
 workflows:
 - name: foo_1-bar_1
   source: foo_1
@@ -72,12 +335,15 @@ workflows:
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := New(tc.config)
+			r := prometheus.NewRegistry()
+			c, err := New(tc.config, r)
 			require.NoError(t, err)
 
 			pm := &plugin.PluginManager{}
 			t.Cleanup(pm.Stop)
-			ss, ds, err := c.ConfigurePlugins(pm, tc.paths)
+			ss, ds, err := c.ConfigurePlugins(pm, tc.paths, tc.strict)
+			assert.Equal(t, tc.nSources, len(ss))
+			assert.Equal(t, tc.nDestinations, len(ds))
 			for _, s := range ss {
 				_, ok := s.(*SourceTyper)
 				assert.True(t, ok)
@@ -86,7 +352,14 @@ workflows:
 				_, ok := d.(*DestinationTyper)
 				assert.True(t, ok)
 			}
-			assert.ErrorIs(t, err, tc.err, errors.Unwrap(err))
+			if tc.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.err.Error())
+			}
+			metricFamilies, err := r.Gather()
+			assert.NoError(t, err)
+			assert.Equal(t, len(metricFamilies), 1)
 		})
 	}
 }

--- a/plugins/s3/main.go
+++ b/plugins/s3/main.go
@@ -47,7 +47,7 @@ func (d *destination) Configure(config map[string]interface{}) error {
 	dc := new(destinationConfig)
 	err := mapstructure.Decode(config, dc)
 	if err != nil {
-		return nil
+		return err
 	}
 	if dc.Endpoint == "" {
 		dc.Endpoint = defaultEndpoint


### PR DESCRIPTION
Sometimes one workflow will be misconfigured, or have some runtime
issue, e.g. when Google Drive permissions are broken, which prevents the
entire ingest binary from starting. This is not always desirable, as
sometimes it is better for some ingestion to work rather than no
ingestion. This commit adds a flag to the binary that allows
misconfigured workflows to be skipped rather than causing the
application to exit with a failure. Whenever workflows are skipped, a
newly added metric is incremented, allowing administrators to alert on
ingest configuration errors rather than blindly running ingest without
realizing that a workflow is not running. This new mode of skipping
failed workflows is disabled by default.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
