### PR TITLE
codec: add meta field

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -11,6 +11,8 @@ type Codec struct {
 	// Name is the name of the resource. Destinations will use this
 	// as the key under which to store objects.
 	Name string `json:"name"`
+	// Meta can optionally store additional data that can be consumed by the dequeuer.
+	Meta []byte `json:"meta"`
 }
 
 // Marshal serializes the Identifiable so it can be sent on the queue.
@@ -24,6 +26,6 @@ func (c *Codec) Unmarshal(data []byte) error {
 }
 
 // NewCodec creates a Codec from an existing Identifiable.
-func NewCodec(id, name string) Codec {
-	return Codec{ID: id, Name: name}
+func NewCodec(id, name string, meta []byte) Codec {
+	return Codec{ID: id, Name: name, Meta: meta}
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,17 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCodecMarshalling(t *testing.T) {
+	c := NewCodec("id", "name", []byte(`{"meta":"value"}`))
+
+	d, err := c.Marshal()
+	assert.NoError(t, err)
+	nc := new(Codec)
+	assert.NoError(t, nc.Unmarshal(d))
+	assert.Equal(t, &c, nc)
+}

--- a/dequeue/dequeue_test.go
+++ b/dequeue/dequeue_test.go
@@ -56,7 +56,7 @@ func TestDequeue(t *testing.T) {
 		q := new(mocks.Queue)
 		s := new(mocks.Storage)
 		sub := new(mocks.Subscription)
-		_t := ingest.NewCodec("bar", "foo")
+		_t := ingest.NewCodec("bar", "foo", nil)
 		data, _ := _t.Marshal()
 		msg := &nats.Msg{Data: data}
 
@@ -118,7 +118,7 @@ func TestDequeue(t *testing.T) {
 		q := new(mocks.Queue)
 		s := new(mocks.Storage)
 		sub := new(mocks.Subscription)
-		_t := ingest.NewCodec("bar", "foo")
+		_t := ingest.NewCodec("bar", "foo", nil)
 		data, _ := _t.Marshal()
 		msg := &nats.Msg{Data: data}
 

--- a/enqueue/enqueue_test.go
+++ b/enqueue/enqueue_test.go
@@ -46,7 +46,7 @@ func TestEnqueue(t *testing.T) {
 		{
 			name: "one entry",
 			expect: func() (*mocks.Queue, *mocks.Nexter, *ingest.Codec) {
-				t := ingest.NewCodec("foo", "foo")
+				t := ingest.NewCodec("foo", "foo", []byte(`{"key":"value"}`))
 				data, _ := t.Marshal()
 				q := new(mocks.Queue)
 				q.On("Publish", "sub", data).Return(nil).Once()
@@ -60,9 +60,9 @@ func TestEnqueue(t *testing.T) {
 		{
 			name: "two entries",
 			expect: func() (*mocks.Queue, *mocks.Nexter, *ingest.Codec) {
-				t := ingest.NewCodec("foo", "foo")
+				t := ingest.NewCodec("foo", "foo", nil)
 				data, _ := t.Marshal()
-				t2 := ingest.NewCodec("foo2", "foo2")
+				t2 := ingest.NewCodec("foo2", "foo2", nil)
 				data2, _ := t2.Marshal()
 				q := new(mocks.Queue)
 				q.
@@ -86,12 +86,9 @@ func TestEnqueue(t *testing.T) {
 			q, n, _ := tc.expect()
 
 			e, err := New(n, "sub", q, reg, logger)
-			if err != nil {
-				t.Error(err)
-			}
-			if err := e.Enqueue(ctx); err != nil {
-				t.Error(err)
-			}
+			assert.NoError(t, err)
+			assert.NoError(t, e.Enqueue(ctx))
+
 			n.AssertExpectations(t)
 			q.AssertExpectations(t)
 

--- a/plugin/noop.go
+++ b/plugin/noop.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// defaultCodec can be used for testing against this noop plugin.
-	defaultCodec  = ingest.NewCodec("id", "name")
+	defaultCodec  = ingest.NewCodec("id", "name", nil)
 	DefaultLogger = hclog.New(&hclog.LoggerOptions{
 		Level:      hclog.Trace,
 		Output:     os.Stderr,
@@ -97,7 +97,7 @@ func (s *noopSource) Next(_ context.Context) (*ingest.Codec, error) {
 
 func (s *noopSource) CleanUp(ctx context.Context, i ingest.Codec) error {
 	s.l.Debug("call cleanup")
-	if i != defaultCodec {
+	if i.ID != defaultCodec.ID {
 		return fmt.Errorf("id %q not found", i.ID)
 	}
 
@@ -106,7 +106,7 @@ func (s *noopSource) CleanUp(ctx context.Context, i ingest.Codec) error {
 
 // Download will take an Element and download it from S3
 func (s *noopSource) Download(ctx context.Context, i ingest.Codec) (*ingest.Object, error) {
-	if i != defaultCodec {
+	if i.ID != defaultCodec.ID {
 		return nil, fmt.Errorf("id %q not found", i.ID)
 	}
 	return &ingest.Object{
@@ -140,7 +140,7 @@ func (d *noopDestination) Configure(config map[string]interface{}) error {
 }
 
 func (d *noopDestination) Stat(ctx context.Context, element ingest.Codec) (*storage.ObjectInfo, error) {
-	if element != defaultCodec {
+	if element.ID != defaultCodec.ID {
 		return nil, os.ErrNotExist
 	}
 	return &storage.ObjectInfo{

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -75,7 +75,7 @@ func TestNewPluginSource(t *testing.T) {
 
 		require.NoError(t, p.CleanUp(ctx, *n))
 
-		require.Error(t, p.CleanUp(ctx, ingest.NewCodec("unknown", "nobody")))
+		require.Error(t, p.CleanUp(ctx, ingest.NewCodec("unknown", "nobody", nil)))
 	})
 
 	t.Run("Configure", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestPluginDestination(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, defaultObjURL, u.URI)
 
-		u, err = p.Stat(ctx, ingest.NewCodec("fake id", "unknown"))
+		u, err = p.Stat(ctx, ingest.NewCodec("fake id", "unknown", nil))
 		assert.Nil(t, u)
 		assert.ErrorIs(t, err, os.ErrNotExist)
 	})

--- a/plugins/s3/main.go
+++ b/plugins/s3/main.go
@@ -146,7 +146,7 @@ func (s *source) Next(_ context.Context) (*ingest.Codec, error) {
 			prefix: s.prefix,
 			name:   strings.TrimPrefix(oi.Key, s.prefix),
 		}
-		c := ingest.NewCodec(e.ID(), e.Name())
+		c := ingest.NewCodec(e.ID(), e.Name(), nil)
 		return &c, nil
 	}
 

--- a/storage/s3/s3_test.go
+++ b/storage/s3/s3_test.go
@@ -18,7 +18,7 @@ func TestStore(t *testing.T) {
 	t.Run("using meta objects", func(t *testing.T) {
 		mc := new(mocks.MinioClient)
 
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 		obj := &ingest.Object{
 			MimeType: "plain/text",
 			Len:      64,
@@ -52,7 +52,7 @@ func TestStore(t *testing.T) {
 	})
 	t.Run("not using meta objects", func(t *testing.T) {
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 		obj := &ingest.Object{
 			MimeType: "plain/text",
 			Len:      64,
@@ -86,7 +86,7 @@ func TestStore(t *testing.T) {
 func TestStat(t *testing.T) {
 	t.Run("no object, no meta object", func(t *testing.T) {
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 
 		mc.On("StatObject", mock.Anything, "bucket", "prefix/bar", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once().
 			On("StatObject", mock.Anything, "bucket", "meta/bar.done", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
@@ -115,7 +115,7 @@ func TestStat(t *testing.T) {
 	})
 	t.Run("object, no meta object", func(t *testing.T) {
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 
 		mc.On("PutObject", mock.Anything, "bucket", "meta/bar.done", mock.Anything, int64(0), mock.Anything).Return(minio.UploadInfo{}, nil).Once()
 		mc.On("StatObject", mock.Anything, "bucket", "prefix/bar", mock.Anything).Return(minio.ObjectInfo{}, nil).Once().
@@ -148,7 +148,7 @@ func TestStat(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		logger = log.With(logger, "caller", log.DefaultCaller)
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 
 		mc.On("StatObject", mock.Anything, "bucket", "meta/bar.done", mock.Anything).Return(minio.ObjectInfo{}, nil)
 
@@ -178,7 +178,7 @@ func TestStat(t *testing.T) {
 	t.Run("object exists", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 
 		mc.On("StatObject", mock.Anything, "bucket", "prefix/bar", mock.Anything).Return(minio.ObjectInfo{}, nil).Once()
 
@@ -206,7 +206,7 @@ func TestStat(t *testing.T) {
 	t.Run("no object", func(t *testing.T) {
 		logger := log.NewJSONLogger(log.NewSyncWriter(os.Stdout))
 		mc := new(mocks.MinioClient)
-		_t := ingest.NewCodec("foo", "bar")
+		_t := ingest.NewCodec("foo", "bar", nil)
 
 		mc.On("StatObject", mock.Anything, "bucket", "prefix/bar", mock.Anything).Return(minio.ObjectInfo{}, minio.ErrorResponse{Code: "NoSuchKey"}).Once()
 


### PR DESCRIPTION
The new field can be used by the individual plugins to pass meta data
form the enqueuer to the dequeuer, or even cross plugins.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
