### PR TITLE
multi-storage: fail fast in during stat

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -157,7 +157,7 @@ workflow:
 					"type":     c.Sources[sourceNames[w.Source]].Type,
 					"name":     c.Sources[sourceNames[w.Source]].Name,
 				})
-			if s == nil {
+			if err != nil {
 				if strict {
 					return nil, nil, fmt.Errorf("cannot instantiate source %q: %w", w.Source, err)
 				}
@@ -187,7 +187,7 @@ workflow:
 							"type":     c.Destinations[destinationNames[d]].Type,
 							"name":     c.Destinations[destinationNames[d]].Name,
 						})
-					if dd == nil {
+					if err != nil {
 						if strict {
 							return nil, nil, fmt.Errorf("cannot instantiate destination %q: %w", d, err)
 						}

--- a/storage/multi/multi_test.go
+++ b/storage/multi/multi_test.go
@@ -32,7 +32,7 @@ func TestMultiStorageStat(t *testing.T) {
 			storages: func(t *testing.T) []storage.Storage {
 				return []storage.Storage{
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), nil).Once(),
 					),
 				}
@@ -44,7 +44,7 @@ func TestMultiStorageStat(t *testing.T) {
 			storages: func(t *testing.T) []storage.Storage {
 				return []storage.Storage{
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Once(),
 					),
 				}
@@ -57,16 +57,16 @@ func TestMultiStorageStat(t *testing.T) {
 			storages: func(t *testing.T) []storage.Storage {
 				return []storage.Storage{
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
-						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Once(),
+						Stat(mock.Anything, codec).
+						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Maybe(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
-						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Once(),
+						Stat(mock.Anything, codec).
+						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Maybe(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
-						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Once(),
+						Stat(mock.Anything, codec).
+						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Maybe(),
 					),
 				}
 			},
@@ -78,15 +78,15 @@ func TestMultiStorageStat(t *testing.T) {
 			storages: func(t *testing.T) []storage.Storage {
 				return []storage.Storage{
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
-						Return((*storage.ObjectInfo)(nil), nil).Once(),
+						Stat(mock.Anything, codec).
+						Return((*storage.ObjectInfo)(nil), nil).Maybe(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
-						Return((*storage.ObjectInfo)(nil), nil).Once(),
+						Stat(mock.Anything, codec).
+						Return((*storage.ObjectInfo)(nil), nil).Maybe(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), os.ErrNotExist).Once(),
 					),
 				}
@@ -99,15 +99,15 @@ func TestMultiStorageStat(t *testing.T) {
 			storages: func(t *testing.T) []storage.Storage {
 				return []storage.Storage{
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), nil).Once(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), nil).Once(),
 					),
 					callToStorage(mocks.NewStorage(t).EXPECT().
-						Stat(context.Background(), codec).
+						Stat(mock.Anything, codec).
 						Return((*storage.ObjectInfo)(nil), nil).Once(),
 					),
 				}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"time"
@@ -42,7 +43,7 @@ func (i instrumentedStorage) Stat(ctx context.Context, element ingest.Codec) (*O
 	oi, err := i.Storage.Stat(ctx, element)
 	if err == nil || os.IsNotExist(err) {
 		i.operationsTotal.WithLabelValues("stat", "success").Inc()
-	} else {
+	} else if !errors.Is(err, context.Canceled) {
 		i.operationsTotal.WithLabelValues("stat", "error").Inc()
 	}
 	return oi, err
@@ -57,7 +58,7 @@ func (i instrumentedStorage) Store(ctx context.Context, element ingest.Codec, ob
 	u, err := i.Storage.Store(ctx, element, obj)
 	if err == nil || os.IsNotExist(err) {
 		i.operationsTotal.WithLabelValues("store", "success").Inc()
-	} else {
+	} else if !errors.Is(err, context.Canceled) {
 		i.operationsTotal.WithLabelValues("store", "error").Inc()
 	}
 	return u, err


### PR DESCRIPTION
Right now, if one of the storages backing a multi-storage returns an
error, the multi-storage still waits for all other storages to finish
responding before returning an error. This is wasteful, since we already
know that the final response of the stat call will be an error. This
commit changes this behavior so that all in-flight stats are canceled
as soon as one error is received.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
