### PR TITLE
config: make plugin metrics use consistent labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,7 +154,7 @@ workflow:
 				c.Sources[sourceNames[w.Source]].Config,
 				prometheus.Labels{
 					"workflow": w.Name,
-					"type":     c.Sources[sourceNames[w.Source]].Type,
+					"plugin":   c.Sources[sourceNames[w.Source]].Type,
 					"name":     c.Sources[sourceNames[w.Source]].Name,
 				})
 			if err != nil {
@@ -184,7 +184,7 @@ workflow:
 						c.Destinations[destinationNames[d]].Config,
 						prometheus.Labels{
 							"workflow": w.Name,
-							"type":     c.Destinations[destinationNames[d]].Type,
+							"plugin":   c.Destinations[destinationNames[d]].Type,
 							"name":     c.Destinations[destinationNames[d]].Name,
 						})
 					if err != nil {

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -52,7 +52,7 @@ func TestPluginManagerWatch(t *testing.T) {
 		t.Cleanup(pm.Stop)
 		t.Cleanup(cancel)
 
-		_, err := pm.NewSource(noopPath, nil, prometheus.Labels{"type": "test"})
+		_, err := pm.NewSource(noopPath, nil, prometheus.Labels{"plugin": "test"})
 		require.NoError(t, err)
 
 		go func() {


### PR DESCRIPTION
Right now, some metrics related to plugins use the `type` label to mark
the plugin type and some metrics use the `plugin` label. This commit
unifies the metrics.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
