### PR TITLE
plugins/drive: fix panic on startup

### DIFF
--- a/plugins/drive/main.go
+++ b/plugins/drive/main.go
@@ -55,5 +55,6 @@ func (d *destination) Configure(config map[string]interface{}) error {
 }
 
 func main() {
-	plugin.RunPluginServer(nil, &destination{}, prometheus.NewPedanticRegistry())
+	reg := prometheus.NewRegistry()
+	plugin.RunPluginServer(nil, &destination{reg: reg}, reg)
 }

--- a/storage/drive/drive.go
+++ b/storage/drive/drive.go
@@ -32,15 +32,17 @@ func New(folder string, service *drive.Service, l hclog.Logger, r prometheus.Reg
 		return nil, errors.New("no folder was specified")
 	}
 	ds := &driveStorage{s: service, l: l}
+
+	ds.gdcot = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Name: "ingest_google_drive_client_operations_total",
+		Help: "The number of operations performed by the Google Drive client.",
+	}, []string{"operation", "result"})
+
 	f, err := ds.find(context.Background(), "", parts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find folder: %w", err)
 	}
 	ds.p = f.Id
-	ds.gdcot = promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-		Name: "ingest_google_drive_client_operations_total",
-		Help: "The number of operations performed by the Google Drive client.",
-	}, []string{"operation", "result"})
 
 	for _, o := range []string{"find", "list", "create"} {
 		for _, r := range []string{"error", "success"} {


### PR DESCRIPTION
Currently, the Google Drive panic panics on startup because the find
method which requires a counter to be incremented, is called before the
counter is initialized.

This commit fixes this issue as well as fixes an issue where the
registry was never passed to the plugin, meaning the and metrics would
never actually be registered.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
