### PR TITLE
Remove the workflow label from plugin

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -153,9 +153,9 @@ workflow:
 				pluginPaths[c.Sources[sourceNames[w.Source]].Type],
 				c.Sources[sourceNames[w.Source]].Config,
 				prometheus.Labels{
-					"workflow": w.Name,
-					"plugin":   c.Sources[sourceNames[w.Source]].Type,
-					"name":     c.Sources[sourceNames[w.Source]].Name,
+					"component": "source",
+					"plugin":    c.Sources[sourceNames[w.Source]].Type,
+					"name":      c.Sources[sourceNames[w.Source]].Name,
 				})
 			if err != nil {
 				if strict {
@@ -183,9 +183,9 @@ workflow:
 						pluginPaths[c.Destinations[destinationNames[d]].Type],
 						c.Destinations[destinationNames[d]].Config,
 						prometheus.Labels{
-							"workflow": w.Name,
-							"plugin":   c.Destinations[destinationNames[d]].Type,
-							"name":     c.Destinations[destinationNames[d]].Name,
+							"component": "destination",
+							"plugin":    c.Destinations[destinationNames[d]].Type,
+							"name":      c.Destinations[destinationNames[d]].Name,
 						})
 					if err != nil {
 						if strict {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -62,11 +62,9 @@ func (pm *PluginManager) Gather() ([]*dto.MetricFamily, error) {
 			}
 			for _, mf := range mfs {
 				for _, m := range mf.Metric {
-					lps := []*dto.LabelPair{{Name: ptr("component"), Value: ptr("source")}}
 					for k, v := range pm.sources[i].labels {
-						lps = append(lps, &dto.LabelPair{Name: ptr(k), Value: ptr(v)})
+						m.Label = append(m.Label, &dto.LabelPair{Name: ptr(k), Value: ptr(v)})
 					}
-					m.Label = append(m.Label, lps...)
 				}
 			}
 			all[i] = mfs
@@ -87,11 +85,9 @@ func (pm *PluginManager) Gather() ([]*dto.MetricFamily, error) {
 			}
 			for _, mf := range mfs {
 				for _, m := range mf.Metric {
-					lps := []*dto.LabelPair{{Name: ptr("component"), Value: ptr("destination")}}
 					for k, v := range pm.destinations[i].labels {
-						lps = append(lps, &dto.LabelPair{Name: ptr(k), Value: ptr(v)})
+						m.Label = append(m.Label, &dto.LabelPair{Name: ptr(k), Value: ptr(v)})
 					}
-					m.Label = append(m.Label, lps...)
 				}
 			}
 			all[i+len(pm.sources)] = mfs


### PR DESCRIPTION
We reuse plugins across workflows. Putting a workflow label on a
plugin's metrics does not make sense and is confusing when a plugin is
used in more than one workflow.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
