### PR TITLE
Feature: plugin rpc call metrics

### DIFF
--- a/plugin/metrics.go
+++ b/plugin/metrics.go
@@ -1,0 +1,121 @@
+package plugin
+
+import (
+	"net/url"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/connylabs/ingest"
+	"github.com/connylabs/ingest/storage"
+)
+
+type instrumentedPluginSourceRPCServer struct {
+	*pluginSourceRPCServer
+	cv *prometheus.CounterVec
+}
+
+func (s *instrumentedPluginSourceRPCServer) Gather(c *any, resp *[]*dto.MetricFamily) error {
+	err := s.pluginSourceRPCServer.Gather(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Gather", "result": "error"}).Inc()
+		return err
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Gather", "result": "success"}).Inc()
+	return nil
+}
+
+func (s *instrumentedPluginSourceRPCServer) Configure(c *map[string]any, resp *any) error {
+	err := s.pluginSourceRPCServer.Configure(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Configure", "result": "error"}).Inc()
+		return err
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Configure", "result": "success"}).Inc()
+	return nil
+}
+
+func (s *instrumentedPluginSourceRPCServer) CleanUp(c *ingest.Codec, resp *any) error {
+	err := s.pluginSourceRPCServer.CleanUp(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "CleanUp", "result": "error"}).Inc()
+		return err
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "CleanUp", "result": "success"}).Inc()
+	return nil
+}
+
+func (s *instrumentedPluginSourceRPCServer) Download(c *ingest.Codec, resp *DownloadResponse) (err error) {
+	err = s.pluginSourceRPCServer.Download(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Download", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Download", "result": "success"}).Inc()
+	return
+}
+
+func (s *instrumentedPluginSourceRPCServer) Next(args any, resp *ingest.Codec) (err error) {
+	err = s.pluginSourceRPCServer.Next(args, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Next", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Next", "result": "success"}).Inc()
+	return
+}
+
+func (s *instrumentedPluginSourceRPCServer) Reset(args any, resp *any) (err error) {
+	err = s.pluginSourceRPCServer.Reset(args, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Reset", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Reset", "result": "success"}).Inc()
+	return
+}
+
+type instrumentedPluginDestinationRPCServer struct {
+	*pluginDestinationRPCServer
+	cv *prometheus.CounterVec
+}
+
+func (s *instrumentedPluginDestinationRPCServer) Gather(c *any, resp *[]*dto.MetricFamily) (err error) {
+	err = s.pluginDestinationRPCServer.Gather(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Gather", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Gather", "result": "success"}).Inc()
+	return
+}
+
+func (s *instrumentedPluginDestinationRPCServer) Configure(c *map[string]any, resp *any) (err error) {
+	err = s.pluginDestinationRPCServer.Configure(c, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Configure", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Configure", "result": "success"}).Inc()
+	return
+}
+
+func (s *instrumentedPluginDestinationRPCServer) Stat(args *ingest.Codec, resp *storage.ObjectInfo) (err error) {
+	err = s.pluginDestinationRPCServer.Stat(args, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Stat", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Stat", "result": "success"}).Inc()
+	return
+}
+
+func (s *instrumentedPluginDestinationRPCServer) Store(args *StoreRequest, resp *url.URL) (err error) {
+	err = s.pluginDestinationRPCServer.Store(args, resp)
+	if err != nil {
+		s.cv.With(prometheus.Labels{"rpc_method": "Store", "result": "error"}).Inc()
+		return
+	}
+	s.cv.With(prometheus.Labels{"rpc_method": "Store", "result": "success"}).Inc()
+	return
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -51,7 +51,14 @@ func (p *pluginSource) Server(mb *hplugin.MuxBroker) (interface{}, error) {
 		g = prometheus.Gatherers{g, p.g}
 	}
 
-	return &pluginSourceRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}, nil
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "plugin_rpc_calls_total",
+		Help: "The total number of rpc calls",
+	}, []string{"rpc_method", "result"})
+	reg.MustRegister(cv)
+	serv := &pluginSourceRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}
+
+	return &instrumentedPluginSourceRPCServer{pluginSourceRPCServer: serv, cv: cv}, nil
 }
 
 func (p *pluginSource) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
@@ -82,5 +89,12 @@ func (p *pluginDestination) Server(mb *hplugin.MuxBroker) (interface{}, error) {
 		g = prometheus.Gatherers{g, p.g}
 	}
 
-	return &pluginDestinationRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}, nil
+	cv := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "plugin_rpc_calls_total",
+		Help: "The total number of rpc calls",
+	}, []string{"rpc_method", "result"})
+	reg.MustRegister(cv)
+	serv := &pluginDestinationRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}
+
+	return &instrumentedPluginDestinationRPCServer{pluginDestinationRPCServer: serv, cv: cv}, nil
 }


### PR DESCRIPTION
The purpose of this PR is to instrument the RPC calls of plugins and gather performance analytics about them

1. Created plugin/metrics.go file and create instrumentation wrappers for plugginSourceRpcServer and plugginDestinationRpcServer and it's Gather, Configure, CleanUp, Download, Next, Reset, Stat and Store methods
* The pluginSourceRPCServer and pluginDestinationRPCServer structs are wrapped using embedded structs
* The methods are called from within wrapper methods under identical names

2. Changed the implementations of `func (p *pluginSource) Server` and `func (p *pluginDestination) Server` functions to return the instrumented versions of the pluginSourceRPCServer & pluginDestinationRPCServer structs, instead of the originals
* These include a copy of the original structs along with a CounterVec that tracks the total number of rpc calls for each method