### PR TITLE
plugin: use options to set logger

### DIFF
--- a/plugin/cmd.go
+++ b/plugin/cmd.go
@@ -18,9 +18,42 @@ const (
 	PluginMagicCookieKey       = "INGEST_PLUGIN"
 )
 
-func RunPluginServer(s Source, d Destination, g prometheus.Gatherer) {
+type Option func(c *configuration)
+
+func WithLogger(l hclog.Logger) Option {
+	return func(c *configuration) {
+		c.l = l
+	}
+}
+
+func WithGatherer(g prometheus.Gatherer) Option {
+	return func(c *configuration) {
+		c.g = g
+	}
+}
+
+type configuration struct {
+	g prometheus.Gatherer
+	l hclog.Logger
+}
+
+func RunPluginServer(s Source, d Destination, opts ...Option) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	c := &configuration{
+		l: hclog.New(&hclog.LoggerOptions{
+			Level:      hclog.Info,
+			Output:     os.Stderr,
+			JSONFormat: true,
+		}),
+	}
+
+	for _, o := range opts {
+		if o != nil {
+			o(c)
+		}
+	}
 
 	handshakeConfig := hplugin.HandshakeConfig{
 		ProtocolVersion:  PluginMagicProtocalVersion,
@@ -28,30 +61,24 @@ func RunPluginServer(s Source, d Destination, g prometheus.Gatherer) {
 		MagicCookieValue: PluginCookieValue,
 	}
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Level:      hclog.Trace,
-		Output:     os.Stderr,
-		JSONFormat: true,
-	})
-
 	pluginMap := map[string]hplugin.Plugin{
 		"source": &pluginSource{
 			impl: s,
 			ctx:  ctx,
-			g:    g,
-			l:    logger.With("component", "source"),
+			g:    c.g,
+			l:    c.l.With("component", "source"),
 		},
 		"destination": &pluginDestination{
 			impl: d,
 			ctx:  ctx,
-			g:    g,
-			l:    logger.With("component", "destination"),
+			g:    c.g,
+			l:    c.l.With("component", "destination"),
 		},
 	}
 
 	hplugin.Serve(&hplugin.ServeConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
-		Logger:          logger,
+		Logger:          c.l,
 	})
 }

--- a/plugin/cmd.go
+++ b/plugin/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	hplugin "github.com/hashicorp/go-plugin"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 const (
@@ -41,12 +42,20 @@ func RunPluginServer(s Source, d Destination, opts ...Option) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	reg := prometheus.NewRegistry()
+
+	reg.MustRegister(
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+	)
+
 	c := &configuration{
 		l: hclog.New(&hclog.LoggerOptions{
 			Level:      hclog.Info,
 			Output:     os.Stderr,
 			JSONFormat: true,
 		}),
+		g: reg,
 	}
 
 	for _, o := range opts {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,7 +8,6 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	hplugin "github.com/hashicorp/go-plugin"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/connylabs/ingest"
 	"github.com/connylabs/ingest/storage"
@@ -39,19 +38,7 @@ type pluginSource struct {
 }
 
 func (p *pluginSource) Server(mb *hplugin.MuxBroker) (interface{}, error) {
-	reg := prometheus.NewRegistry()
-
-	reg.MustRegister(
-		collectors.NewGoCollector(),
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-	)
-
-	var g prometheus.Gatherer = reg
-	if p.g != nil {
-		g = prometheus.Gatherers{g, p.g}
-	}
-
-	return &pluginSourceRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}, nil
+	return &pluginSourceRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: p.g}, nil
 }
 
 func (p *pluginSource) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interface{}, error) {
@@ -70,17 +57,5 @@ func (p *pluginDestination) Client(mb *hplugin.MuxBroker, c *rpc.Client) (interf
 }
 
 func (p *pluginDestination) Server(mb *hplugin.MuxBroker) (interface{}, error) {
-	reg := prometheus.NewRegistry()
-
-	reg.MustRegister(
-		collectors.NewGoCollector(),
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-	)
-
-	var g prometheus.Gatherer = reg
-	if p.g != nil {
-		g = prometheus.Gatherers{g, p.g}
-	}
-
-	return &pluginDestinationRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: g}, nil
+	return &pluginDestinationRPCServer{Impl: p.impl, mb: mb, l: p.l, ctx: p.ctx, g: p.g}, nil
 }

--- a/plugin/rpc.go
+++ b/plugin/rpc.go
@@ -40,7 +40,6 @@ func (s *pluginSourceRPCServer) Gather(c *any, resp *[]*dto.MetricFamily) error 
 }
 
 func (s *pluginSourceRPCServer) CleanUp(c *ingest.Codec, resp *any) error {
-	s.l.Error("this is the server")
 	if !s.configured {
 		return ErrNotConfigured
 	}

--- a/plugins/drive/main.go
+++ b/plugins/drive/main.go
@@ -56,5 +56,5 @@ func (d *destination) Configure(config map[string]interface{}) error {
 
 func main() {
 	reg := prometheus.NewRegistry()
-	plugin.RunPluginServer(nil, &destination{reg: reg}, reg)
+	plugin.RunPluginServer(nil, &destination{reg: reg}, plugin.WithGatherer(reg))
 }

--- a/plugins/drive/main.go
+++ b/plugins/drive/main.go
@@ -56,5 +56,5 @@ func (d *destination) Configure(config map[string]interface{}) error {
 
 func main() {
 	reg := prometheus.NewRegistry()
-	plugin.RunPluginServer(nil, &destination{reg: reg}, plugin.WithGatherer(reg))
+	plugin.RunPluginServer(nil, &destination{reg: reg})
 }

--- a/plugins/noop/main.go
+++ b/plugins/noop/main.go
@@ -15,5 +15,5 @@ func main() {
 	})
 	reg.MustRegister(c)
 	c.Set(1)
-	iplugin.RunPluginServer(iplugin.NewNoopSource(iplugin.DefaultLogger), iplugin.NewNoopDestination(iplugin.DefaultLogger), reg)
+	iplugin.RunPluginServer(iplugin.NewNoopSource(iplugin.DefaultLogger), iplugin.NewNoopDestination(iplugin.DefaultLogger), iplugin.WithGatherer(reg), iplugin.WithLogger(iplugin.DefaultLogger))
 }

--- a/plugins/s3/main.go
+++ b/plugins/s3/main.go
@@ -176,5 +176,5 @@ func (s *source) Download(ctx context.Context, i ingest.Codec) (*ingest.Object, 
 }
 
 func main() {
-	iplugin.RunPluginServer(&source{}, &destination{}, nil)
+	iplugin.RunPluginServer(&source{}, &destination{})
 }


### PR DESCRIPTION
When starting the plugin server, allow the developer to set the
Registerer and the logger with an Option. This way plugins can use that
defined logger in there own manner. Before it was not possible to write
custom log messages.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
