### PR TITLE
config/: expand environment variables in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,8 @@ func NewFromPath(path string, r prometheus.Registerer) (*Config, error) {
 func New(buf []byte, r prometheus.Registerer) (*Config, error) {
 	c := new(Config)
 
+	buf = []byte(os.ExpandEnv(string(buf)))
+
 	if err := yaml.Unmarshal(buf, c); err != nil {
 		return nil, fmt.Errorf("unable to read configuration YAML: %w", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -10,6 +11,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewWithEnv(t *testing.T) {
+	secret := "secret"
+	os.Setenv("INGEST_SECRET", secret)
+
+	c, err := New([]byte(`
+sources:
+- name: foo_1
+  type: s3
+  accessKey: $INGEST_SECRET
+`), nil)
+	require.NoError(t, err)
+	i, ok := c.Sources[0].Config["accessKey"]
+	require.True(t, ok, "accessKey not in map")
+	t.Log(i)
+	s, ok := i.(string)
+	require.True(t, ok, "accessKey is not string")
+
+	assert.Equal(t, secret, s)
+}
 
 func TestNew(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
Use environment variables in the configuration file with
`os.ExpandEnv`. Strings like `$VAR` or `${VAR}` will be replaced by the
corresponding environment variables.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
