### PR TITLE
plugin/manager.go: skip on failed Gather

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -58,7 +58,8 @@ func (pm *PluginManager) Gather() ([]*dto.MetricFamily, error) {
 			}
 			mfs, err := g.Gather()
 			if err != nil {
-				return err
+				level.Error(pm.l).Log("msg", "failed to gather metrics for plugin", "err", err.Error(), "path", pm.sources[i].path, "mode", "source")
+				return nil
 			}
 			for _, mf := range mfs {
 				for _, m := range mf.Metric {
@@ -81,7 +82,9 @@ func (pm *PluginManager) Gather() ([]*dto.MetricFamily, error) {
 
 			mfs, err := g.Gather()
 			if err != nil {
-				return err
+				level.Error(pm.l).Log("msg", "failed to gather metrics for plugin", "err", err.Error(), "path", pm.destinations[i].path, "mode", "destination")
+				return nil
+
 			}
 			for _, mf := range mfs {
 				for _, m := range mf.Metric {


### PR DESCRIPTION
If a plugin does not return valid prometheus metrics for the Gather
call, we were failing the whole operation for all plugins. So one
failing call makes it impossible to collect any metrics from ingest.
This commit will log and skip that plugin.
To follow up, we should collect metrics of the rpc client to see if
Gather calls are failing.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
